### PR TITLE
feat(taxi-route): click-to-add taxi route with canvas overlay

### DIFF
--- a/src/components/Map/hooks/index.ts
+++ b/src/components/Map/hooks/index.ts
@@ -18,3 +18,4 @@ export { usePinDrop } from './usePinDrop';
 export { useTrackControl } from './useTrackControl';
 export { useIdleOrbit } from './useIdleOrbit';
 export { useTerrainShading } from './useTerrainShading';
+export { useTaxiRouteSync } from './useTaxiRouteSync';

--- a/src/components/Map/hooks/useTaxiRouteSync.ts
+++ b/src/components/Map/hooks/useTaxiRouteSync.ts
@@ -1,0 +1,286 @@
+/**
+ * Canvas overlay for taxi route rendering.
+ *
+ * Users click on the map to add waypoints. Lines are drawn between them
+ * on a transparent canvas over the map. Simple, reliable, no pathfinding.
+ *
+ * Visual: green glow lines with animated pulse, direction arrows,
+ * numbered waypoint markers.
+ */
+import { useEffect, useRef } from 'react';
+import { useTaxiModeActive, useTaxiRouteStore } from '@/stores/taxiRouteStore';
+import type { MapRef } from './useMapSetup';
+
+// Green glow colours
+const LINE_COLOR = '#22c55e';
+const GLOW_COLOR = 'rgba(34, 197, 94, 0.3)';
+const CASING_COLOR = '#ffffff';
+const ARROW_COLOR = '#ffffff';
+const LABEL_COLOR = '#ffffff';
+
+// Animation
+const PULSE_SPEED = 0.03;
+
+function drawRoute(
+  ctx: CanvasRenderingContext2D,
+  map: maplibregl.Map,
+  waypoints: { longitude: number; latitude: number }[],
+  width: number,
+  height: number,
+  phase: number
+): void {
+  ctx.clearRect(0, 0, width, height);
+  if (waypoints.length === 0) return;
+
+  const zoom = map.getZoom();
+  const scale = Math.max(0.5, Math.min(3.5, (zoom - 13) / 4));
+
+  // Project all waypoints
+  const pts = waypoints.map((wp) => map.project([wp.longitude, wp.latitude]));
+
+  if (pts.length >= 2) {
+    // --- Glow ---
+    ctx.save();
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    ctx.moveTo(pts[0]!.x, pts[0]!.y);
+    for (let i = 1; i < pts.length; i++) {
+      ctx.lineTo(pts[i]!.x, pts[i]!.y);
+    }
+    ctx.strokeStyle = GLOW_COLOR;
+    ctx.lineWidth = 20 * scale;
+    ctx.stroke();
+    ctx.restore();
+
+    // --- Casing ---
+    ctx.save();
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.globalAlpha = 0.85;
+    ctx.beginPath();
+    ctx.moveTo(pts[0]!.x, pts[0]!.y);
+    for (let i = 1; i < pts.length; i++) {
+      ctx.lineTo(pts[i]!.x, pts[i]!.y);
+    }
+    ctx.strokeStyle = CASING_COLOR;
+    ctx.lineWidth = 9 * scale;
+    ctx.stroke();
+    ctx.restore();
+
+    // --- Core green line ---
+    ctx.save();
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    ctx.moveTo(pts[0]!.x, pts[0]!.y);
+    for (let i = 1; i < pts.length; i++) {
+      ctx.lineTo(pts[i]!.x, pts[i]!.y);
+    }
+    ctx.strokeStyle = LINE_COLOR;
+    ctx.lineWidth = 5 * scale;
+    ctx.stroke();
+    ctx.restore();
+
+    // --- Animated pulse dashes ---
+    const totalLen = pts.reduce((sum, p, i) => {
+      if (i === 0) return 0;
+      const prev = pts[i - 1]!;
+      return sum + Math.hypot(p.x - prev.x, p.y - prev.y);
+    }, 0);
+
+    if (totalLen > 0) {
+      ctx.save();
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      const dashOffset = (phase % 1) * totalLen;
+      ctx.setLineDash([14 * scale, 22 * scale]);
+      ctx.lineDashOffset = -dashOffset;
+      ctx.beginPath();
+      ctx.moveTo(pts[0]!.x, pts[0]!.y);
+      for (let i = 1; i < pts.length; i++) {
+        ctx.lineTo(pts[i]!.x, pts[i]!.y);
+      }
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.45)';
+      ctx.lineWidth = 3 * scale;
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.restore();
+    }
+
+    // --- Direction arrows along segments ---
+    ctx.save();
+    ctx.globalAlpha = 0.7;
+    const arrowSize = 7 * scale;
+    for (let i = 1; i < pts.length; i++) {
+      const p1 = pts[i - 1]!;
+      const p2 = pts[i]!;
+      const segLen = Math.hypot(p2.x - p1.x, p2.y - p1.y);
+      if (segLen < 40 * scale) continue;
+
+      const spacing = 80 * scale;
+      const count = Math.floor(segLen / spacing);
+      for (let j = 1; j <= count; j++) {
+        const t = j / (count + 1);
+        const mx = p1.x + (p2.x - p1.x) * t;
+        const my = p1.y + (p2.y - p1.y) * t;
+        const angle = Math.atan2(p2.y - p1.y, p2.x - p1.x);
+
+        ctx.beginPath();
+        ctx.moveTo(mx + arrowSize * Math.cos(angle), my + arrowSize * Math.sin(angle));
+        ctx.lineTo(
+          mx + arrowSize * Math.cos(angle + (2.5 * Math.PI) / 3),
+          my + arrowSize * Math.sin(angle + (2.5 * Math.PI) / 3)
+        );
+        ctx.lineTo(
+          mx + arrowSize * Math.cos(angle - (2.5 * Math.PI) / 3),
+          my + arrowSize * Math.sin(angle - (2.5 * Math.PI) / 3)
+        );
+        ctx.closePath();
+        ctx.fillStyle = ARROW_COLOR;
+        ctx.fill();
+      }
+    }
+    ctx.restore();
+  }
+
+  // --- Waypoint markers ---
+  ctx.save();
+  for (let i = 0; i < pts.length; i++) {
+    const p = pts[i]!;
+    const r = 11 * scale;
+
+    ctx.globalAlpha = 0.9;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, r + 3.5, 0, Math.PI * 2);
+    ctx.fillStyle = CASING_COLOR;
+    ctx.fill();
+
+    ctx.globalAlpha = 1;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, r, 0, Math.PI * 2);
+    ctx.fillStyle = LINE_COLOR;
+    ctx.fill();
+
+    if (pts.length > 1) {
+      const fontSize = Math.max(13, 16 * scale);
+      ctx.font = `bold ${fontSize}px sans-serif`;
+      ctx.fillStyle = LABEL_COLOR;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(`${i + 1}`, p.x, p.y + 0.5);
+    }
+  }
+  ctx.restore();
+}
+
+export function useTaxiRouteSync(mapRef: MapRef): void {
+  const waypoints = useTaxiRouteStore((s) => s.waypoints);
+  const taxiModeActive = useTaxiModeActive();
+  const clickModeEnabled = useTaxiRouteStore((s) => s.clickModeEnabled);
+  const addWaypoint = useTaxiRouteStore((s) => s.addWaypoint);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const phaseRef = useRef(0);
+  const rafRef = useRef<number>(0);
+
+  // Create canvas overlay once
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const container = map.getContainer();
+    const canvas = document.createElement('canvas');
+    canvas.style.position = 'absolute';
+    canvas.style.top = '0';
+    canvas.style.left = '0';
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
+    canvas.style.pointerEvents = 'none';
+    canvas.style.zIndex = '10';
+    container.appendChild(canvas);
+    canvasRef.current = canvas;
+
+    const resize = () => {
+      const rect = container.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
+    };
+    resize();
+
+    const observer = new ResizeObserver(resize);
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      canvas.remove();
+      canvasRef.current = null;
+    };
+  }, [mapRef]);
+
+  // Click-to-add waypoint — listen on the map container directly
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const handleMapClick = (e: maplibregl.MapMouseEvent) => {
+      if (!taxiModeActive || !clickModeEnabled) return;
+      addWaypoint(e.lngLat.lng, e.lngLat.lat);
+    };
+
+    map.on('click', handleMapClick);
+    return () => {
+      map.off('click', handleMapClick);
+    };
+  }, [mapRef, taxiModeActive, clickModeEnabled, addWaypoint]);
+
+  // Animated render loop
+  useEffect(() => {
+    const map = mapRef.current;
+    const canvas = canvasRef.current;
+    if (!map || !canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const theWaypoints = taxiModeActive ? waypoints : [];
+    const needsAnimation = theWaypoints.length >= 2;
+
+    const render = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const w = canvas.width / dpr;
+      const h = canvas.height / dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      drawRoute(ctx, map, theWaypoints, w, h, phaseRef.current);
+
+      if (needsAnimation) {
+        phaseRef.current += PULSE_SPEED;
+        rafRef.current = requestAnimationFrame(render);
+      }
+    };
+
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    render();
+
+    const onMove = () => {
+      if (!needsAnimation) {
+        const dpr = window.devicePixelRatio || 1;
+        const w = canvas.width / dpr;
+        const h = canvas.height / dpr;
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        drawRoute(ctx, map, theWaypoints, w, h, phaseRef.current);
+      }
+    };
+    map.on('move', onMove);
+    map.on('zoom', onMove);
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      map.off('move', onMove);
+      map.off('zoom', onMove);
+    };
+  }, [mapRef, waypoints, taxiModeActive]);
+}

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -39,6 +39,7 @@ import {
   useProcedureRouteSync,
   useRangeRingsSync,
   useRouteLineSync,
+  useTaxiRouteSync,
   useTerrainShading,
   useTrackControl,
   useVatsimSync,
@@ -322,6 +323,9 @@ export default function Map({ airports }: MapProps) {
 
   // Range rings sync - renders reach circles from selected airport
   useRangeRingsSync({ mapRef, navDataLocation });
+
+  // Taxi route sync - highlights matched taxi edges on the map
+  useTaxiRouteSync(mapRef);
 
   // Pin-drop custom start location
   const { placeAtCenter: handlePinDrop, placeAtCoordinates: handlePinDropAtCoordinates } =

--- a/src/components/layout/AirportInfoPanel/tabs/StartTab.tsx
+++ b/src/components/layout/AirportInfoPanel/tabs/StartTab.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils/helpers';
 import { useAppStore } from '@/stores/appStore';
 import type { Helipad, Runway, StartupLocation } from '@/types/apt';
 import { NamedPosition } from '@/types/geo';
+import TaxiRouteInline from './TaxiRouteInline';
 
 type ViewType = 'gates' | 'runways' | 'helipads';
 
@@ -265,53 +266,57 @@ function GateList({ gates, searchQuery, onSelect, selectedIndex }: GateListProps
         const hasBadges = sizeConfig || opConfig;
 
         return (
-          <Button
-            key={originalIndex}
-            data-selected={isSelected || undefined}
-            variant="ghost"
-            onClick={() =>
-              onSelect?.({
-                latitude: gate.latitude,
-                longitude: gate.longitude,
-                name: gate.name,
-                heading: gate.heading,
-                index: originalIndex,
-                xplaneIndex: xplaneIndices[originalIndex],
-              })
-            }
-            className={cn(
-              'h-auto w-full flex-col items-stretch rounded px-2.5 py-2 text-left',
-              isSelected
-                ? 'bg-cat-emerald/10 text-cat-emerald'
-                : 'text-foreground/80 hover:bg-muted/50'
-            )}
-          >
-            {/* Row 1: Name + Heading */}
-            <div className="flex items-center justify-between">
-              <span className="font-mono text-sm">{gate.name}</span>
-              <div className="flex items-center gap-2">
-                <span className="text-[10px] text-muted-foreground/50">
-                  {Math.round(gate.heading)}°
-                </span>
-                {isSelected && <Check className="h-3.5 w-3.5" />}
+          <div key={originalIndex}>
+            <Button
+              key={originalIndex}
+              data-selected={isSelected || undefined}
+              variant="ghost"
+              onClick={() =>
+                onSelect?.({
+                  latitude: gate.latitude,
+                  longitude: gate.longitude,
+                  name: gate.name,
+                  heading: gate.heading,
+                  index: originalIndex,
+                  xplaneIndex: xplaneIndices[originalIndex],
+                })
+              }
+              className={cn(
+                'h-auto w-full flex-col items-stretch rounded px-2.5 py-2 text-left',
+                isSelected
+                  ? 'bg-cat-emerald/10 text-cat-emerald'
+                  : 'text-foreground/80 hover:bg-muted/50'
+              )}
+            >
+              {/* Row 1: Name + Heading */}
+              <div className="flex items-center justify-between">
+                <span className="font-mono text-sm">{gate.name}</span>
+                <div className="flex items-center gap-2">
+                  <span className="text-[10px] text-muted-foreground/50">
+                    {Math.round(gate.heading)}°
+                  </span>
+                  {isSelected && <Check className="h-3.5 w-3.5" />}
+                </div>
               </div>
-            </div>
-            {/* Row 2: Badges */}
-            {hasBadges && (
-              <div className="mt-1 flex gap-1.5">
-                {sizeConfig && (
-                  <Badge variant={sizeConfig.variant} className="h-4 px-1.5 text-[9px]">
-                    {t(sizeConfig.labelKey)}
-                  </Badge>
-                )}
-                {opConfig && (
-                  <Badge variant={opConfig.variant} className="h-4 px-1.5 text-[9px]">
-                    {t(opConfig.labelKey)}
-                  </Badge>
-                )}
-              </div>
-            )}
-          </Button>
+              {/* Row 2: Badges */}
+              {hasBadges && (
+                <div className="mt-1 flex gap-1.5">
+                  {sizeConfig && (
+                    <Badge variant={sizeConfig.variant} className="h-4 px-1.5 text-[9px]">
+                      {t(sizeConfig.labelKey)}
+                    </Badge>
+                  )}
+                  {opConfig && (
+                    <Badge variant={opConfig.variant} className="h-4 px-1.5 text-[9px]">
+                      {t(opConfig.labelKey)}
+                    </Badge>
+                  )}
+                </div>
+              )}
+            </Button>
+            {/* Taxi route input — appears under the selected gate */}
+            {isSelected && <TaxiRouteInline />}
+          </div>
         );
       })}
     </div>

--- a/src/components/layout/AirportInfoPanel/tabs/TaxiRouteInline.tsx
+++ b/src/components/layout/AirportInfoPanel/tabs/TaxiRouteInline.tsx
@@ -1,0 +1,104 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CircleDot, Eraser, MousePointerClick, RotateCcw, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useAppStore } from '@/stores/appStore';
+import { useTaxiRouteStore } from '@/stores/taxiRouteStore';
+
+/**
+ * Inline taxi route panel — click-to-add waypoints on the map.
+ *
+ * Shows the list of placed waypoints, undo/clear buttons,
+ * and instructions for the user.
+ */
+export default function TaxiRouteInline() {
+  const { t } = useTranslation();
+
+  const icao = useAppStore((s) => s.selectedICAO);
+  const waypoints = useTaxiRouteStore((s) => s.waypoints);
+  const clickModeEnabled = useTaxiRouteStore((s) => s.clickModeEnabled);
+  const removeLastWaypoint = useTaxiRouteStore((s) => s.removeLastWaypoint);
+  const clearRoute = useTaxiRouteStore((s) => s.clearRoute);
+  const deactivate = useTaxiRouteStore((s) => s.deactivate);
+  const setActiveAirport = useTaxiRouteStore((s) => s.setActiveAirport);
+  const setClickModeEnabled = useTaxiRouteStore((s) => s.setClickModeEnabled);
+
+  // Activate taxi mode for this airport on mount, deactivate on unmount
+  useEffect(() => {
+    if (icao) setActiveAirport(icao);
+    return () => {
+      deactivate();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="mt-1.5 space-y-1.5 rounded-md border border-cat-emerald/20 bg-cat-emerald/5 px-2 py-2">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5 text-cat-emerald/80">
+          <CircleDot className="h-3 w-3" />
+          <span className="text-[11px] font-medium">
+            {t('airportInfo.taxiRoute.label', 'Taxi Route')}
+          </span>
+        </div>
+        <div className="flex gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={removeLastWaypoint}
+            disabled={waypoints.length === 0}
+            className="h-6 w-6 text-muted-foreground/60 hover:text-foreground"
+            title="Undo last point"
+          >
+            <RotateCcw className="h-3 w-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={clearRoute}
+            disabled={waypoints.length === 0}
+            className="h-6 w-6 text-muted-foreground/60 hover:text-foreground"
+            title="Clear all"
+          >
+            <Eraser className="h-3 w-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setClickModeEnabled(!clickModeEnabled)}
+            className={`h-6 w-6 ${clickModeEnabled ? 'text-cat-emerald' : 'text-muted-foreground/60 hover:text-foreground'}`}
+            title={clickModeEnabled ? 'Disable click-to-add' : 'Enable click-to-add'}
+          >
+            <MousePointerClick className="h-3 w-3" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={deactivate}
+            className="h-6 w-6 text-muted-foreground/60 hover:text-foreground"
+            title="Close"
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Instructions or waypoint count */}
+      {clickModeEnabled && waypoints.length === 0 ? (
+        <p className="text-[10px] text-muted-foreground/50">
+          Click on the map to add taxi route points
+        </p>
+      ) : clickModeEnabled && waypoints.length > 0 ? (
+        <p className="text-[10px] text-cat-emerald/60">
+          {waypoints.length} point{waypoints.length !== 1 ? 's' : ''} placed — click to add more
+        </p>
+      ) : (
+        <p className="text-[10px] text-muted-foreground/50">
+          Click the <MousePointerClick className="inline h-2.5 w-2.5" /> button to enable
+          click-to-add
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -26,7 +26,6 @@
     "approved": "Genehmigt",
     "recommended": "Empfohlen"
   },
-
   "units": {
     "ft": "ft",
     "m": "m",
@@ -36,7 +35,6 @@
     "kg": "kg",
     "fpm": "fpm"
   },
-
   "directions": {
     "n": "N",
     "e": "O",
@@ -47,11 +45,9 @@
     "se": "SO",
     "sw": "SW"
   },
-
   "app": {
     "title": "X-Dispatch"
   },
-
   "setup": {
     "title": "X-Dispatch",
     "subtitle": "Wählen Sie Ihre X-Plane Installation aus, um zu beginnen",
@@ -62,7 +58,6 @@
     "failedToBrowse": "Ordnerauswahl konnte nicht geöffnet werden",
     "failedToSave": "Speichern fehlgeschlagen"
   },
-
   "loading": {
     "title": "X-Dispatch",
     "badge": "Daten werden geladen",
@@ -85,7 +80,6 @@
     "scanningCustom": "Custom Scenery {{current}}/{{total}}: {{name}}",
     "savingToDb": "Speichern in der Datenbank..."
   },
-
   "toolbar": {
     "searchPlaceholder": "Flughäfen suchen...",
     "clearSearch": "Suche löschen",
@@ -127,7 +121,6 @@
       "settings": "Einstellungen öffnen"
     }
   },
-
   "airportFilters": {
     "title": "Flughäfen",
     "type": "Typ",
@@ -146,7 +139,6 @@
     "minRunways": "{{count}}+ Bahnen",
     "reset": "Filter zurücksetzen"
   },
-
   "settings": {
     "title": "Einstellungen",
     "subtitle": "Konfigurieren Sie Ihre Präferenzen",
@@ -271,7 +263,6 @@
       }
     }
   },
-
   "sidebar": {
     "weather": "Wetter",
     "weatherDetails": "Wetterdetails",
@@ -302,7 +293,6 @@
     "noRunwaysFound": "Keine Bahnen gefunden",
     "copyFrequency": "Frequenz kopieren"
   },
-
   "airportInfo": {
     "tabs": {
       "info": "Info",
@@ -395,15 +385,19 @@
       "updateAvailable": "Gateway hat eine neuere Version",
       "credit": "von {{artist}} · {{date}}",
       "viewOnGateway": "Auf Gateway ansehen"
+    },
+    "taxiRoute": {
+      "label": "Taxi-Route",
+      "placeholder": "z.B. A B1 C",
+      "matchCount": "{{count}} Seg",
+      "noMatch": "kein Treffer"
     }
   },
-
   "navigation": {
     "heading": "KURS",
     "wind": "WIND",
     "calm": "Windstille"
   },
-
   "flightStrip": {
     "notDetected": "X-Plane läuft nicht",
     "ias": "IAS",
@@ -418,7 +412,6 @@
     "center": "Zentrieren",
     "centerTooltip": "Karte auf Flugzeug zentrieren"
   },
-
   "weather": {
     "fetching": "Wetter wird abgerufen...",
     "noData": "Keine Wetterdaten verfügbar",
@@ -438,7 +431,6 @@
     "tailwind": "RW",
     "crosswind": "SW"
   },
-
   "procedures": {
     "noData": "Keine Verfahren verfügbar",
     "noTypeData": "Keine {{type}}s verfügbar",
@@ -449,7 +441,6 @@
     },
     "allRunways": "ALLE"
   },
-
   "layers": {
     "airport": {
       "title": "Flughafen-Ebenen",
@@ -493,7 +484,6 @@
     "showAll": "Alle anzeigen",
     "hideAll": "Alle ausblenden"
   },
-
   "debug": {
     "title": "Debug-Modus aktiv",
     "instruction": "Klicken Sie auf ein Element auf der Karte, um seine Eigenschaften zu inspizieren.",
@@ -510,7 +500,6 @@
     "copyToClipboard": "Kopieren",
     "clearSelection": "Auswahl löschen"
   },
-
   "launcher": {
     "title": "Flug-Konfiguration",
     "launch": "X-Plane starten",
@@ -520,7 +509,6 @@
     "xplaneRunning": "X-Plane läuft - Flug wird über API geändert",
     "selectDeparture": "Wählen Sie einen Abflugort auf der Karte",
     "selectAircraft": "Wählen Sie ein Flugzeug",
-
     "aircraft": {
       "title": "Flugzeug",
       "search": "Flugzeug suchen...",
@@ -533,13 +521,11 @@
       "showAll": "Alle anzeigen",
       "showFavoritesOnly": "Nur Favoriten anzeigen"
     },
-
     "liveries": {
       "title": "Bemalungen",
       "count": "Bemalungen ({{count}})",
       "default": "Standard"
     },
-
     "config": {
       "timeOfDay": "Tageszeit",
       "realWorldTime": "Echtzeit",
@@ -551,12 +537,10 @@
       "departure": "Abflug",
       "livery": "Bemalung"
     },
-
     "startState": {
       "ready": "Bereit",
       "cold": "Kalt & Dunkel"
     },
-
     "time": {
       "live": "Live",
       "set": "Einstellen",
@@ -565,7 +549,6 @@
       "dusk": "Dämmerung",
       "night": "Nacht"
     },
-
     "timePresets": {
       "dawn": "Morgengrauen",
       "sunrise": "Sonnenaufgang",
@@ -574,7 +557,6 @@
       "dusk": "Dämmerung",
       "night": "Nacht"
     },
-
     "weather": {
       "real": "Live",
       "clear": "Klar",
@@ -584,7 +566,6 @@
       "snowy": "Schnee",
       "foggy": "Neblig"
     },
-
     "weatherBuilder": {
       "custom": "Benutzerdefiniertes Wetter",
       "customize": "Wetter anpassen",
@@ -613,29 +594,24 @@
         "cumulonimbus": "Cumulonimbus"
       }
     },
-
     "weatherModal": {
       "presets": "Voreinstellungen",
       "custom": "Benutzerdefiniert",
       "poor": "Schlecht",
       "unlimited": "Unbegrenzt"
     },
-
     "weatherDialog": {
       "title": "Wettereinstellungen",
       "done": "Fertig",
       "addCloud": "Wolkenschicht",
       "addWind": "Windschicht",
-
       "layerProperties": "Schicht-Eigenschaften",
       "emptyHint": "Klicken Sie auf eine Wolken- oder Windschicht im Diagramm zum Bearbeiten",
-
       "cloudType": "Wolkentyp",
       "cloudCoverage": "Wolkenbedeckung",
       "tops": "Obergrenze",
       "bases": "Untergrenze",
       "deleteCloud": "Wolkenschicht {{n}} löschen",
-
       "cloudTypes": {
         "cirrus": "Cirrus",
         "stratus": "Stratus",
@@ -648,7 +624,6 @@
         "broken": "Bkn",
         "overcast": "Ovc"
       },
-
       "altitude": "Höhe",
       "direction": "Richtung",
       "speed": "Geschwindigkeit",
@@ -656,7 +631,6 @@
       "shear": "Windscherung",
       "turbulence": "Turbulenz",
       "deleteWind": "Windschicht {{n}} löschen",
-
       "atmosphere": "Atmosphäre",
       "visibility": "Sicht",
       "precipitation": "Niederschlag",
@@ -664,7 +638,6 @@
       "precipSevere": "Stark",
       "temperature": "Temperatur",
       "altimeter": "Höhenmesser",
-
       "environment": "Umgebung",
       "terrain": "Gelände",
       "terrainCondition": "Zustand",
@@ -682,7 +655,6 @@
         "medium": "Mittel",
         "heavy": "Stark"
       },
-
       "waves": "Wellen",
       "waveHeight": "Höhe",
       "waveDirection": "Richtung",
@@ -700,19 +672,16 @@
         "rapidly_deteriorating": "Schnell verschlechternd"
       }
     },
-
     "fuelConfig": {
       "auto": "Auto",
       "manual": "Manuell",
       "total": "Gesamt"
     },
-
     "fuelModal": {
       "empty": "Leer",
       "full": "Voll",
       "of": "von"
     },
-
     "logbook": {
       "title": "Flugbuch",
       "clearAll": "Alle löschen",
@@ -720,7 +689,6 @@
       "emptyHint": "Ihre letzten 10 Flüge erscheinen hier nach dem Start"
     }
   },
-
   "addonManager": {
     "title": "Addon-Manager",
     "openXPlaneFolder": "X-Plane Ordner öffnen",
@@ -884,7 +852,6 @@
       "Navdata": "Navigationsdaten"
     }
   },
-
   "simbrief": {
     "title": "Von SimBrief importieren",
     "description": "Ihren letzten Flugplan von SimBrief abrufen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -27,7 +27,6 @@
     "approved": "Approved",
     "recommended": "Recommended"
   },
-
   "units": {
     "ft": "ft",
     "m": "m",
@@ -37,7 +36,6 @@
     "kg": "kg",
     "fpm": "fpm"
   },
-
   "directions": {
     "n": "N",
     "e": "E",
@@ -48,11 +46,9 @@
     "se": "SE",
     "sw": "SW"
   },
-
   "app": {
     "title": "X-Dispatch"
   },
-
   "setup": {
     "title": "X-Dispatch",
     "subtitle": "Select your X-Plane installation to get started",
@@ -63,7 +59,6 @@
     "failedToBrowse": "Failed to open folder picker",
     "failedToSave": "Failed to save"
   },
-
   "loading": {
     "title": "X-Dispatch",
     "badge": "Loading data",
@@ -87,7 +82,6 @@
     "scanningCustom": "Scanning Custom Scenery {{current}}/{{total}}: {{name}}",
     "savingToDb": "Saving to database..."
   },
-
   "toolbar": {
     "searchPlaceholder": "Search airports...",
     "clearSearch": "Clear search",
@@ -150,7 +144,6 @@
       "settings": "Open settings"
     }
   },
-
   "airportFilters": {
     "title": "Airports",
     "type": "Type",
@@ -158,15 +151,13 @@
     "seaplane": "Seaplane Bases",
     "heliport": "Heliports",
     "surface": "Surface",
-    "paved": "Paved (Asphalt/Concrete)",
-    "unpaved": "Unpaved (Grass/Dirt/Gravel)",
+    "paved": "Paved",
+    "unpaved": "Unpaved",
     "showOnly": "Show Only",
     "iataOnly": "Commercial (IATA)",
     "customOnly": "Custom Scenery",
     "surfaceType": "Surface Type",
     "runwaySurface": "Runway Surface",
-    "paved": "Paved",
-    "unpaved": "Unpaved",
     "water": "Water",
     "surfaceOther": "Other",
     "country": "Country",
@@ -176,7 +167,6 @@
     "minRunways": "{{count}}+ Runways",
     "reset": "Reset Filters"
   },
-
   "explore": {
     "title": "Explore",
     "close": "Close explore",
@@ -219,7 +209,6 @@
       }
     }
   },
-
   "settings": {
     "title": "Settings",
     "subtitle": "Configure your preferences",
@@ -262,7 +251,6 @@
       "crashReports": "Send crash reports",
       "crashReportsDescription": "Help improve X-Dispatch by automatically sending crash reports",
       "crashReportsNote": "Restart required for changes to take effect. No personal data is collected.",
-      "developer": "Developer",
       "debugOverlay": "Debug Overlay",
       "debugOverlayDescription": "Show the developer debug toolbar",
       "toggleDebug": "Toggle",
@@ -377,7 +365,6 @@
       }
     }
   },
-
   "sidebar": {
     "weather": "Weather",
     "weatherDetails": "Weather Details",
@@ -412,7 +399,6 @@
       "noActivity": "No VATSIM activity"
     }
   },
-
   "airportInfo": {
     "tabs": {
       "info": "Info",
@@ -505,15 +491,19 @@
       "updateAvailable": "Gateway has a newer release",
       "credit": "by {{artist}} · {{date}}",
       "viewOnGateway": "View on Gateway"
+    },
+    "taxiRoute": {
+      "label": "Taxi Route",
+      "placeholder": "e.g. A B1 C",
+      "matchCount": "{{count}} seg",
+      "noMatch": "no match"
     }
   },
-
   "navigation": {
     "heading": "HEADING",
     "wind": "WIND",
     "calm": "Calm"
   },
-
   "flightStrip": {
     "notDetected": "X-Plane not running",
     "ias": "IAS",
@@ -532,7 +522,6 @@
     "reconnect": "Reconnect",
     "reconnectTooltip": "Force reconnect to X-Plane simulator"
   },
-
   "weather": {
     "fetching": "Fetching weather...",
     "noData": "No weather data available",
@@ -552,7 +541,6 @@
     "tailwind": "TW",
     "crosswind": "XW"
   },
-
   "procedures": {
     "noData": "No procedures available",
     "noTypeData": "No {{type}}s available",
@@ -563,7 +551,6 @@
     },
     "allRunways": "ALL"
   },
-
   "layers": {
     "airport": {
       "title": "Airport Layers",
@@ -604,7 +591,6 @@
     "showAll": "Show All",
     "hideAll": "Hide All"
   },
-
   "debug": {
     "title": "Debug Mode Active",
     "instruction": "Click on any feature on the map to inspect its properties.",
@@ -621,7 +607,6 @@
     "copyToClipboard": "Copy to clipboard",
     "clearSelection": "Clear selection"
   },
-
   "launcher": {
     "title": "Flight Setup",
     "launch": "Launch X-Plane",
@@ -631,7 +616,6 @@
     "xplaneRunning": "X-Plane is running - flight will be changed via API",
     "selectDeparture": "Select a departure on the map",
     "selectAircraft": "Select an aircraft",
-
     "aircraft": {
       "title": "Aircraft",
       "search": "Search aircraft...",
@@ -650,20 +634,17 @@
       "showAll": "Show all",
       "showFavoritesOnly": "Show favorites only"
     },
-
     "liveries": {
       "title": "Liveries",
       "count": "Liveries ({{count}})",
       "default": "Default"
     },
-
     "specs": {
       "emptyWeight": "Empty",
       "maxWeight": "MTOW",
       "maxFuel": "Fuel Cap",
       "tailNumber": "Tail"
     },
-
     "config": {
       "timeOfDay": "Time of Day",
       "realWorldTime": "Real World",
@@ -675,12 +656,10 @@
       "departure": "Departure",
       "livery": "Livery"
     },
-
     "startState": {
       "ready": "Ready",
       "cold": "Cold & Dark"
     },
-
     "time": {
       "live": "Live",
       "set": "Set",
@@ -691,7 +670,6 @@
       "dusk": "Dusk",
       "night": "Night"
     },
-
     "timePresets": {
       "dawn": "Dawn",
       "sunrise": "Sunrise",
@@ -700,7 +678,6 @@
       "dusk": "Dusk",
       "night": "Night"
     },
-
     "weather": {
       "real": "Real",
       "clear": "Clear",
@@ -710,7 +687,6 @@
       "snowy": "Snowy",
       "foggy": "Foggy"
     },
-
     "weatherBuilder": {
       "custom": "Custom Weather",
       "customize": "Customize weather",
@@ -739,29 +715,24 @@
         "cumulonimbus": "Cumulonimbus"
       }
     },
-
     "weatherModal": {
       "presets": "Presets",
       "custom": "Custom",
       "poor": "Poor",
       "unlimited": "Unlimited"
     },
-
     "weatherDialog": {
       "title": "Weather Settings",
       "done": "Done",
       "addCloud": "Cloud Layer",
       "addWind": "Wind Layer",
-
       "layerProperties": "Layer Properties",
       "emptyHint": "Click a cloud or wind layer in the diagram to edit",
-
       "cloudType": "Cloud Type",
       "cloudCoverage": "Cloud Coverage",
       "tops": "Tops",
       "bases": "Bases",
       "deleteCloud": "Delete Cloud Layer {{n}}",
-
       "cloudTypes": {
         "cirrus": "Cirrus",
         "stratus": "Stratus",
@@ -774,7 +745,6 @@
         "broken": "Bkn",
         "overcast": "Ovc"
       },
-
       "altitude": "Altitude",
       "direction": "Direction",
       "speed": "Speed",
@@ -782,7 +752,6 @@
       "shear": "Shear",
       "turbulence": "Turbulence",
       "deleteWind": "Delete Wind Layer {{n}}",
-
       "atmosphere": "Atmosphere",
       "visibility": "Visibility",
       "precipitation": "Precipitation",
@@ -790,7 +759,6 @@
       "precipSevere": "Severe",
       "temperature": "Temperature",
       "altimeter": "Altimeter",
-
       "environment": "Environment",
       "terrain": "Terrain",
       "terrainCondition": "Condition",
@@ -808,7 +776,6 @@
         "medium": "Medium",
         "heavy": "Heavy"
       },
-
       "waves": "Waves",
       "waveHeight": "Height",
       "waveDirection": "Direction",
@@ -826,19 +793,16 @@
         "rapidly_deteriorating": "Rapidly Deteriorating"
       }
     },
-
     "fuelConfig": {
       "auto": "Auto",
       "manual": "Manual",
       "total": "Total"
     },
-
     "fuelModal": {
       "empty": "Empty",
       "full": "Full",
       "of": "of"
     },
-
     "logbook": {
       "title": "Flight Logbook",
       "clearAll": "Clear All",
@@ -846,7 +810,6 @@
       "emptyHint": "Your last 10 flights will appear here after launching"
     }
   },
-
   "addonManager": {
     "title": "Addon Manager",
     "openXPlaneFolder": "Open X-Plane Folder",
@@ -1018,7 +981,6 @@
       "Navdata": "Navigation Data"
     }
   },
-
   "simbrief": {
     "title": "Import from SimBrief",
     "description": "Fetch your latest flight plan from SimBrief",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -26,7 +26,6 @@
     "approved": "Aprobado",
     "recommended": "Recomendado"
   },
-
   "units": {
     "ft": "ft",
     "m": "m",
@@ -36,7 +35,6 @@
     "kg": "kg",
     "fpm": "fpm"
   },
-
   "directions": {
     "n": "N",
     "e": "E",
@@ -47,11 +45,9 @@
     "se": "SE",
     "sw": "SO"
   },
-
   "app": {
     "title": "X-Dispatch"
   },
-
   "setup": {
     "title": "X-Dispatch",
     "subtitle": "Selecciona tu instalación de X-Plane para comenzar",
@@ -62,7 +58,6 @@
     "failedToBrowse": "Error al abrir el selector de carpetas",
     "failedToSave": "Error al guardar"
   },
-
   "loading": {
     "title": "X-Dispatch",
     "badge": "Cargando datos",
@@ -85,7 +80,6 @@
     "scanningCustom": "Analizando Custom Scenery {{current}}/{{total}}: {{name}}",
     "savingToDb": "Guardando en la base de datos..."
   },
-
   "toolbar": {
     "searchPlaceholder": "Buscar aeropuertos...",
     "clearSearch": "Limpiar búsqueda",
@@ -127,7 +121,6 @@
       "settings": "Abrir ajustes"
     }
   },
-
   "airportFilters": {
     "title": "Aeropuertos",
     "type": "Tipo",
@@ -146,7 +139,6 @@
     "minRunways": "{{count}}+ Pistas",
     "reset": "Restablecer filtros"
   },
-
   "explore": {
     "title": "Explorar",
     "close": "Cerrar exploración",
@@ -189,7 +181,6 @@
       }
     }
   },
-
   "settings": {
     "title": "Configuración",
     "subtitle": "Configura tus preferencias",
@@ -335,7 +326,6 @@
       }
     }
   },
-
   "sidebar": {
     "weather": "Clima",
     "weatherDetails": "Detalles del clima",
@@ -370,7 +360,6 @@
       "noActivity": "Sin actividad VATSIM"
     }
   },
-
   "airportInfo": {
     "tabs": {
       "info": "Info",
@@ -463,15 +452,19 @@
       "updateAvailable": "Gateway tiene una versión más reciente",
       "credit": "por {{artist}} · {{date}}",
       "viewOnGateway": "Ver en Gateway"
+    },
+    "taxiRoute": {
+      "label": "Ruta de taxi",
+      "placeholder": "ej. A B1 C",
+      "matchCount": "{{count}} seg",
+      "noMatch": "sin coincidencia"
     }
   },
-
   "navigation": {
     "heading": "RUMBO",
     "wind": "VIENTO",
     "calm": "Calma"
   },
-
   "flightStrip": {
     "notDetected": "X-Plane no está ejecutándose",
     "ias": "IAS",
@@ -486,7 +479,6 @@
     "center": "Centrar",
     "centerTooltip": "Centrar mapa en la aeronave"
   },
-
   "weather": {
     "fetching": "Obteniendo clima...",
     "noData": "Sin datos meteorológicos disponibles",
@@ -506,7 +498,6 @@
     "tailwind": "TW",
     "crosswind": "XW"
   },
-
   "procedures": {
     "noData": "Sin procedimientos disponibles",
     "noTypeData": "Sin {{type}}s disponibles",
@@ -517,7 +508,6 @@
     },
     "allRunways": "TODOS"
   },
-
   "layers": {
     "airport": {
       "title": "Capas del aeropuerto",
@@ -561,7 +551,6 @@
     "showAll": "Mostrar todo",
     "hideAll": "Ocultar todo"
   },
-
   "debug": {
     "title": "Modo debug activo",
     "instruction": "Haz clic en cualquier elemento del mapa para inspeccionar sus propiedades.",
@@ -578,7 +567,6 @@
     "copyToClipboard": "Copiar al portapapeles",
     "clearSelection": "Limpiar selección"
   },
-
   "launcher": {
     "title": "Configuración de vuelo",
     "launch": "Iniciar X-Plane",
@@ -588,7 +576,6 @@
     "xplaneRunning": "X-Plane está ejecutándose - el vuelo se cambiará vía API",
     "selectDeparture": "Selecciona una salida en el mapa",
     "selectAircraft": "Selecciona una aeronave",
-
     "aircraft": {
       "title": "Aeronave",
       "search": "Buscar aeronave...",
@@ -607,20 +594,17 @@
       "showAll": "Mostrar todos",
       "showFavoritesOnly": "Mostrar solo favoritos"
     },
-
     "liveries": {
       "title": "Libreas",
       "count": "Libreas ({{count}})",
       "default": "Por defecto"
     },
-
     "specs": {
       "emptyWeight": "Vacío",
       "maxWeight": "MTOW",
       "maxFuel": "Cap. combustible",
       "tailNumber": "Matrícula"
     },
-
     "config": {
       "timeOfDay": "Hora del día",
       "realWorldTime": "Mundo real",
@@ -632,12 +616,10 @@
       "departure": "Salida",
       "livery": "Librea"
     },
-
     "startState": {
       "ready": "Listo",
       "cold": "Frío y Apagado"
     },
-
     "time": {
       "live": "En vivo",
       "set": "Establecer",
@@ -646,7 +628,6 @@
       "dusk": "Atardecer",
       "night": "Noche"
     },
-
     "timePresets": {
       "dawn": "Amanecer",
       "sunrise": "Salida del sol",
@@ -655,7 +636,6 @@
       "dusk": "Atardecer",
       "night": "Noche"
     },
-
     "weather": {
       "real": "Real",
       "clear": "Despejado",
@@ -665,7 +645,6 @@
       "snowy": "Nevado",
       "foggy": "Niebla"
     },
-
     "weatherBuilder": {
       "custom": "Clima personalizado",
       "customize": "Personalizar clima",
@@ -694,29 +673,24 @@
         "cumulonimbus": "Cumulonimbos"
       }
     },
-
     "weatherModal": {
       "presets": "Preajustes",
       "custom": "Personalizado",
       "poor": "Pobre",
       "unlimited": "Ilimitada"
     },
-
     "weatherDialog": {
       "title": "Ajustes de clima",
       "done": "Listo",
       "addCloud": "Capa de nubes",
       "addWind": "Capa de viento",
-
       "layerProperties": "Propiedades de capa",
       "emptyHint": "Haz clic en una capa de nubes o viento en el diagrama para editar",
-
       "cloudType": "Tipo de nube",
       "cloudCoverage": "Cobertura de nubes",
       "tops": "Topes",
       "bases": "Bases",
       "deleteCloud": "Eliminar capa de nubes {{n}}",
-
       "cloudTypes": {
         "cirrus": "Cirros",
         "stratus": "Estratos",
@@ -729,7 +703,6 @@
         "broken": "Bkn",
         "overcast": "Ovc"
       },
-
       "altitude": "Altitud",
       "direction": "Dirección",
       "speed": "Velocidad",
@@ -737,7 +710,6 @@
       "shear": "Cizalladura",
       "turbulence": "Turbulencia",
       "deleteWind": "Eliminar capa de viento {{n}}",
-
       "atmosphere": "Atmósfera",
       "visibility": "Visibilidad",
       "precipitation": "Precipitación",
@@ -745,7 +717,6 @@
       "precipSevere": "Severa",
       "temperature": "Temperatura",
       "altimeter": "Altímetro",
-
       "environment": "Entorno",
       "terrain": "Terreno",
       "terrainCondition": "Condición",
@@ -763,7 +734,6 @@
         "medium": "Media",
         "heavy": "Fuerte"
       },
-
       "waves": "Olas",
       "waveHeight": "Altura",
       "waveDirection": "Dirección",
@@ -781,19 +751,16 @@
         "rapidly_deteriorating": "Deterioro rápido"
       }
     },
-
     "fuelConfig": {
       "auto": "Auto",
       "manual": "Manual",
       "total": "Total"
     },
-
     "fuelModal": {
       "empty": "Vacío",
       "full": "Lleno",
       "of": "de"
     },
-
     "logbook": {
       "title": "Libro de vuelo",
       "clearAll": "Borrar todo",
@@ -801,7 +768,6 @@
       "emptyHint": "Tus últimos 10 vuelos aparecerán aquí después del lanzamiento"
     }
   },
-
   "addonManager": {
     "title": "Gestor de addons",
     "openXPlaneFolder": "Abrir carpeta X-Plane",
@@ -965,7 +931,6 @@
       "Navdata": "Datos de navegación"
     }
   },
-
   "simbrief": {
     "title": "Importar desde SimBrief",
     "description": "Obtener tu último plan de vuelo desde SimBrief",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -26,7 +26,6 @@
     "approved": "Approuvé",
     "recommended": "Recommandé"
   },
-
   "units": {
     "ft": "ft",
     "m": "m",
@@ -36,7 +35,6 @@
     "kg": "kg",
     "fpm": "fpm"
   },
-
   "directions": {
     "n": "N",
     "e": "E",
@@ -47,11 +45,9 @@
     "se": "SE",
     "sw": "SO"
   },
-
   "app": {
     "title": "X-Dispatch"
   },
-
   "setup": {
     "title": "X-Dispatch",
     "subtitle": "Sélectionnez votre installation X-Plane pour commencer",
@@ -62,7 +58,6 @@
     "failedToBrowse": "Impossible d'ouvrir le sélecteur de dossier",
     "failedToSave": "Échec de l'enregistrement"
   },
-
   "loading": {
     "title": "X-Dispatch",
     "badge": "Chargement des données",
@@ -85,7 +80,6 @@
     "scanningCustom": "Analyse des scènes personnalisées {{current}}/{{total}} : {{name}}",
     "savingToDb": "Enregistrement dans la base de données..."
   },
-
   "toolbar": {
     "searchPlaceholder": "Rechercher des aéroports...",
     "clearSearch": "Effacer la recherche",
@@ -127,7 +121,6 @@
       "settings": "Ouvrir les paramètres"
     }
   },
-
   "airportFilters": {
     "title": "Aéroports",
     "type": "Type",
@@ -146,7 +139,6 @@
     "minRunways": "{{count}}+ Pistes",
     "reset": "Réinitialiser les filtres"
   },
-
   "settings": {
     "title": "Paramètres",
     "subtitle": "Configurez vos préférences",
@@ -271,7 +263,6 @@
       }
     }
   },
-
   "sidebar": {
     "weather": "Météo",
     "weatherDetails": "Détails météo",
@@ -302,7 +293,6 @@
     "noRunwaysFound": "Aucune piste trouvée",
     "copyFrequency": "Copier la fréquence"
   },
-
   "airportInfo": {
     "tabs": {
       "info": "Info",
@@ -395,15 +385,19 @@
       "updateAvailable": "Gateway a une version plus récente",
       "credit": "par {{artist}} · {{date}}",
       "viewOnGateway": "Voir sur Gateway"
+    },
+    "taxiRoute": {
+      "label": "Route taxi",
+      "placeholder": "ex. A B1 C",
+      "matchCount": "{{count}} seg",
+      "noMatch": "aucun"
     }
   },
-
   "navigation": {
     "heading": "CAP",
     "wind": "VENT",
     "calm": "Calme"
   },
-
   "flightStrip": {
     "notDetected": "X-Plane non démarré",
     "ias": "IAS",
@@ -418,7 +412,6 @@
     "center": "Centrer",
     "centerTooltip": "Centrer la carte sur l'avion"
   },
-
   "weather": {
     "fetching": "Récupération de la météo...",
     "noData": "Aucune donnée météo disponible",
@@ -438,7 +431,6 @@
     "tailwind": "VA",
     "crosswind": "VT"
   },
-
   "procedures": {
     "noData": "Aucune procédure disponible",
     "noTypeData": "Aucune {{type}} disponible",
@@ -449,7 +441,6 @@
     },
     "allRunways": "TOUT"
   },
-
   "layers": {
     "airport": {
       "title": "Couches d'aéroport",
@@ -493,7 +484,6 @@
     "showAll": "Tout afficher",
     "hideAll": "Tout masquer"
   },
-
   "debug": {
     "title": "Mode débogage actif",
     "instruction": "Cliquez sur n'importe quelle entité sur la carte pour inspecter ses propriétés.",
@@ -510,7 +500,6 @@
     "copyToClipboard": "Copier",
     "clearSelection": "Effacer la sélection"
   },
-
   "launcher": {
     "title": "Configuration du vol",
     "launch": "Lancer X-Plane",
@@ -520,7 +509,6 @@
     "xplaneRunning": "X-Plane est en cours - le vol sera changé via l'API",
     "selectDeparture": "Sélectionnez un départ sur la carte",
     "selectAircraft": "Sélectionnez un aéronef",
-
     "aircraft": {
       "title": "Aéronef",
       "search": "Rechercher un aéronef...",
@@ -533,13 +521,11 @@
       "showAll": "Tout afficher",
       "showFavoritesOnly": "Afficher les favoris uniquement"
     },
-
     "liveries": {
       "title": "Livrées",
       "count": "Livrées ({{count}})",
       "default": "Par défaut"
     },
-
     "config": {
       "timeOfDay": "Heure du jour",
       "realWorldTime": "Temps réel",
@@ -551,12 +537,10 @@
       "departure": "Départ",
       "livery": "Livrée"
     },
-
     "startState": {
       "ready": "Prêt",
       "cold": "Froid & Éteint"
     },
-
     "time": {
       "live": "En direct",
       "set": "Définir",
@@ -565,7 +549,6 @@
       "dusk": "Crépuscule",
       "night": "Nuit"
     },
-
     "timePresets": {
       "dawn": "Aube",
       "sunrise": "Lever du soleil",
@@ -574,7 +557,6 @@
       "dusk": "Crépuscule",
       "night": "Nuit"
     },
-
     "weather": {
       "real": "Réel",
       "clear": "Dégagé",
@@ -584,7 +566,6 @@
       "snowy": "Neigeux",
       "foggy": "Brumeux"
     },
-
     "weatherBuilder": {
       "custom": "Météo personnalisée",
       "customize": "Personnaliser la météo",
@@ -613,29 +594,24 @@
         "cumulonimbus": "Cumulonimbus"
       }
     },
-
     "weatherModal": {
       "presets": "Préréglages",
       "custom": "Personnalisé",
       "poor": "Faible",
       "unlimited": "Illimitée"
     },
-
     "weatherDialog": {
       "title": "Paramètres météo",
       "done": "Terminé",
       "addCloud": "Couche nuageuse",
       "addWind": "Couche de vent",
-
       "layerProperties": "Propriétés de la couche",
       "emptyHint": "Cliquez sur une couche nuageuse ou de vent dans le diagramme pour la modifier",
-
       "cloudType": "Type de nuage",
       "cloudCoverage": "Couverture nuageuse",
       "tops": "Sommets",
       "bases": "Bases",
       "deleteCloud": "Supprimer la couche nuageuse {{n}}",
-
       "cloudTypes": {
         "cirrus": "Cirrus",
         "stratus": "Stratus",
@@ -648,7 +624,6 @@
         "broken": "Bkn",
         "overcast": "Ovc"
       },
-
       "altitude": "Altitude",
       "direction": "Direction",
       "speed": "Vitesse",
@@ -656,7 +631,6 @@
       "shear": "Cisaillement",
       "turbulence": "Turbulence",
       "deleteWind": "Supprimer la couche de vent {{n}}",
-
       "atmosphere": "Atmosphère",
       "visibility": "Visibilité",
       "precipitation": "Précipitations",
@@ -664,7 +638,6 @@
       "precipSevere": "Sévères",
       "temperature": "Température",
       "altimeter": "Altimètre",
-
       "environment": "Environnement",
       "terrain": "Terrain",
       "terrainCondition": "État",
@@ -682,7 +655,6 @@
         "medium": "Moyenne",
         "heavy": "Forte"
       },
-
       "waves": "Vagues",
       "waveHeight": "Hauteur",
       "waveDirection": "Direction",
@@ -700,19 +672,16 @@
         "rapidly_deteriorating": "Dégradation rapide"
       }
     },
-
     "fuelConfig": {
       "auto": "Auto",
       "manual": "Manuel",
       "total": "Total"
     },
-
     "fuelModal": {
       "empty": "Vide",
       "full": "Plein",
       "of": "sur"
     },
-
     "logbook": {
       "title": "Carnet de vol",
       "clearAll": "Tout effacer",
@@ -720,7 +689,6 @@
       "emptyHint": "Vos 10 derniers vols apparaîtront ici après le lancement"
     }
   },
-
   "addonManager": {
     "title": "Gestionnaire d'addons",
     "openXPlaneFolder": "Ouvrir le dossier X-Plane",
@@ -884,7 +852,6 @@
       "Navdata": "Données de navigation"
     }
   },
-
   "simbrief": {
     "title": "Importer depuis SimBrief",
     "description": "Récupérer votre dernier plan de vol depuis SimBrief",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -26,7 +26,6 @@
     "approved": "Approvato",
     "recommended": "Consigliato"
   },
-
   "units": {
     "ft": "ft",
     "m": "m",
@@ -36,7 +35,6 @@
     "kg": "kg",
     "fpm": "fpm"
   },
-
   "directions": {
     "n": "N",
     "e": "E",
@@ -47,11 +45,9 @@
     "se": "SE",
     "sw": "SO"
   },
-
   "app": {
     "title": "X-Dispatch"
   },
-
   "setup": {
     "title": "X-Dispatch",
     "subtitle": "Seleziona la tua installazione di X-Plane per iniziare",
@@ -62,7 +58,6 @@
     "failedToBrowse": "Impossibile aprire il selettore cartelle",
     "failedToSave": "Impossibile salvare"
   },
-
   "loading": {
     "title": "X-Dispatch",
     "badge": "Caricamento dati",
@@ -85,7 +80,6 @@
     "scanningCustom": "Analisi Custom Scenery {{current}}/{{total}}: {{name}}",
     "savingToDb": "Salvataggio nel database..."
   },
-
   "toolbar": {
     "searchPlaceholder": "Cerca aeroporti...",
     "clearSearch": "Cancella ricerca",
@@ -127,7 +121,6 @@
       "settings": "Apri impostazioni"
     }
   },
-
   "airportFilters": {
     "title": "Aeroporti",
     "type": "Tipo",
@@ -146,7 +139,6 @@
     "minRunways": "{{count}}+ Piste",
     "reset": "Reimposta filtri"
   },
-
   "explore": {
     "title": "Esplora",
     "close": "Chiudi esplorazione",
@@ -189,7 +181,6 @@
       }
     }
   },
-
   "settings": {
     "title": "Impostazioni",
     "subtitle": "Configura le tue preferenze",
@@ -335,7 +326,6 @@
       }
     }
   },
-
   "sidebar": {
     "weather": "Meteo",
     "weatherDetails": "Dettagli meteo",
@@ -370,7 +360,6 @@
       "noActivity": "Nessuna attività VATSIM"
     }
   },
-
   "airportInfo": {
     "tabs": {
       "info": "Info",
@@ -463,15 +452,19 @@
       "updateAvailable": "Gateway ha una versione più recente",
       "credit": "di {{artist}} · {{date}}",
       "viewOnGateway": "Visualizza su Gateway"
+    },
+    "taxiRoute": {
+      "label": "Rotta taxi",
+      "placeholder": "es. A B1 C",
+      "matchCount": "{{count}} seg",
+      "noMatch": "nessuno"
     }
   },
-
   "navigation": {
     "heading": "PRUA",
     "wind": "VENTO",
     "calm": "Calmo"
   },
-
   "flightStrip": {
     "notDetected": "X-Plane non in esecuzione",
     "ias": "IAS",
@@ -486,7 +479,6 @@
     "center": "Centra",
     "centerTooltip": "Centra la mappa sull'aereo"
   },
-
   "weather": {
     "fetching": "Recupero meteo...",
     "noData": "Nessun dato meteo disponibile",
@@ -506,7 +498,6 @@
     "tailwind": "TW",
     "crosswind": "XW"
   },
-
   "procedures": {
     "noData": "Nessuna procedura disponibile",
     "noTypeData": "Nessun {{type}} disponibile",
@@ -517,7 +508,6 @@
     },
     "allRunways": "TUTTI"
   },
-
   "layers": {
     "airport": {
       "title": "Livelli aeroporto",
@@ -561,7 +551,6 @@
     "showAll": "Mostra tutto",
     "hideAll": "Nascondi tutto"
   },
-
   "debug": {
     "title": "Modalità debug attiva",
     "instruction": "Clicca su qualsiasi elemento sulla mappa per ispezionare le sue proprietà.",
@@ -578,7 +567,6 @@
     "copyToClipboard": "Copia negli appunti",
     "clearSelection": "Cancella selezione"
   },
-
   "launcher": {
     "title": "Configurazione volo",
     "launch": "Avvia X-Plane",
@@ -588,7 +576,6 @@
     "xplaneRunning": "X-Plane è in esecuzione - il volo verrà cambiato via API",
     "selectDeparture": "Seleziona una partenza sulla mappa",
     "selectAircraft": "Seleziona un aereo",
-
     "aircraft": {
       "title": "Aereo",
       "search": "Cerca aereo...",
@@ -607,20 +594,17 @@
       "showAll": "Mostra tutti",
       "showFavoritesOnly": "Mostra solo preferiti"
     },
-
     "liveries": {
       "title": "Livree",
       "count": "Livree ({{count}})",
       "default": "Predefinita"
     },
-
     "specs": {
       "emptyWeight": "Vuoto",
       "maxWeight": "MTOW",
       "maxFuel": "Cap. carburante",
       "tailNumber": "Marche"
     },
-
     "config": {
       "timeOfDay": "Ora del giorno",
       "realWorldTime": "Mondo reale",
@@ -632,12 +616,10 @@
       "departure": "Partenza",
       "livery": "Livrea"
     },
-
     "startState": {
       "ready": "Pronto",
       "cold": "Freddo e Spento"
     },
-
     "time": {
       "live": "In diretta",
       "set": "Imposta",
@@ -646,7 +628,6 @@
       "dusk": "Crepuscolo",
       "night": "Notte"
     },
-
     "timePresets": {
       "dawn": "Alba",
       "sunrise": "Sorgere del sole",
@@ -655,7 +636,6 @@
       "dusk": "Crepuscolo",
       "night": "Notte"
     },
-
     "weather": {
       "real": "Reale",
       "clear": "Sereno",
@@ -665,7 +645,6 @@
       "snowy": "Nevoso",
       "foggy": "Nebbioso"
     },
-
     "weatherBuilder": {
       "custom": "Meteo personalizzato",
       "customize": "Personalizza meteo",
@@ -694,29 +673,24 @@
         "cumulonimbus": "Cumulonembo"
       }
     },
-
     "weatherModal": {
       "presets": "Preimpostazioni",
       "custom": "Personalizzato",
       "poor": "Scarsa",
       "unlimited": "Illimitata"
     },
-
     "weatherDialog": {
       "title": "Impostazioni meteo",
       "done": "Fatto",
       "addCloud": "Strato di nuvole",
       "addWind": "Strato di vento",
-
       "layerProperties": "Proprietà dello strato",
       "emptyHint": "Clicca su uno strato di nuvole o vento nel diagramma per modificarlo",
-
       "cloudType": "Tipo di nube",
       "cloudCoverage": "Copertura nuvolosa",
       "tops": "Sommità",
       "bases": "Basi",
       "deleteCloud": "Elimina strato di nuvole {{n}}",
-
       "cloudTypes": {
         "cirrus": "Cirro",
         "stratus": "Strato",
@@ -729,7 +703,6 @@
         "broken": "Bkn",
         "overcast": "Ovc"
       },
-
       "altitude": "Altitudine",
       "direction": "Direzione",
       "speed": "Velocità",
@@ -737,7 +710,6 @@
       "shear": "Wind shear",
       "turbulence": "Turbolenza",
       "deleteWind": "Elimina strato di vento {{n}}",
-
       "atmosphere": "Atmosfera",
       "visibility": "Visibilità",
       "precipitation": "Precipitazioni",
@@ -745,7 +717,6 @@
       "precipSevere": "Forte",
       "temperature": "Temperatura",
       "altimeter": "Altimetro",
-
       "environment": "Ambiente",
       "terrain": "Terreno",
       "terrainCondition": "Condizione",
@@ -763,7 +734,6 @@
         "medium": "Media",
         "heavy": "Forte"
       },
-
       "waves": "Onde",
       "waveHeight": "Altezza",
       "waveDirection": "Direzione",
@@ -781,19 +751,16 @@
         "rapidly_deteriorating": "Peggioramento rapido"
       }
     },
-
     "fuelConfig": {
       "auto": "Auto",
       "manual": "Manuale",
       "total": "Totale"
     },
-
     "fuelModal": {
       "empty": "Vuoto",
       "full": "Pieno",
       "of": "di"
     },
-
     "logbook": {
       "title": "Registro voli",
       "clearAll": "Cancella tutto",
@@ -801,7 +768,6 @@
       "emptyHint": "I tuoi ultimi 10 voli appariranno qui dopo il lancio"
     }
   },
-
   "addonManager": {
     "title": "Gestore addon",
     "openXPlaneFolder": "Apri cartella X-Plane",
@@ -965,7 +931,6 @@
       "Navdata": "Dati di navigazione"
     }
   },
-
   "simbrief": {
     "title": "Importa da SimBrief",
     "description": "Recupera il tuo ultimo piano di volo da SimBrief",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -26,7 +26,6 @@
     "approved": "承認済み",
     "recommended": "推奨"
   },
-
   "units": {
     "ft": "ft",
     "m": "m",
@@ -36,7 +35,6 @@
     "kg": "kg",
     "fpm": "fpm"
   },
-
   "directions": {
     "n": "北",
     "e": "東",
@@ -47,11 +45,9 @@
     "se": "南東",
     "sw": "南西"
   },
-
   "app": {
     "title": "X-Dispatch"
   },
-
   "setup": {
     "title": "X-Dispatch",
     "subtitle": "開始するにはX-Planeのインストール先を選択してください",
@@ -62,7 +58,6 @@
     "failedToBrowse": "フォルダ選択を開けませんでした",
     "failedToSave": "保存に失敗しました"
   },
-
   "loading": {
     "title": "X-Dispatch",
     "badge": "データ読み込み中",
@@ -85,7 +80,6 @@
     "scanningCustom": "カスタムシーナリーをスキャン中 {{current}}/{{total}}: {{name}}",
     "savingToDb": "データベースに保存中..."
   },
-
   "toolbar": {
     "searchPlaceholder": "空港を検索...",
     "clearSearch": "検索をクリア",
@@ -127,7 +121,6 @@
       "settings": "設定を開く"
     }
   },
-
   "airportFilters": {
     "title": "空港",
     "type": "種類",
@@ -146,7 +139,6 @@
     "minRunways": "{{count}}本以上",
     "reset": "フィルターをリセット"
   },
-
   "explore": {
     "title": "探索",
     "close": "探索を閉じる",
@@ -189,7 +181,6 @@
       }
     }
   },
-
   "settings": {
     "title": "設定",
     "subtitle": "設定をカスタマイズ",
@@ -335,7 +326,6 @@
       }
     }
   },
-
   "sidebar": {
     "weather": "天気",
     "weatherDetails": "天気の詳細",
@@ -370,7 +360,6 @@
       "noActivity": "VATSIMアクティビティなし"
     }
   },
-
   "airportInfo": {
     "tabs": {
       "info": "情報",
@@ -463,15 +452,19 @@
       "updateAvailable": "Gatewayに新しいリリースがあります",
       "credit": "{{artist}} · {{date}}",
       "viewOnGateway": "Gatewayで表示"
+    },
+    "taxiRoute": {
+      "label": "タクシールート",
+      "placeholder": "例: A B1 C",
+      "matchCount": "{{count}}セグ",
+      "noMatch": "該当なし"
     }
   },
-
   "navigation": {
     "heading": "方位",
     "wind": "風",
     "calm": "穏やか"
   },
-
   "flightStrip": {
     "notDetected": "X-Planeが実行されていません",
     "ias": "IAS",
@@ -486,7 +479,6 @@
     "center": "中央",
     "centerTooltip": "機体を中心にマップを表示"
   },
-
   "weather": {
     "fetching": "天気を取得中...",
     "noData": "気象データがありません",
@@ -506,7 +498,6 @@
     "tailwind": "追風",
     "crosswind": "横風"
   },
-
   "procedures": {
     "noData": "手順がありません",
     "noTypeData": "{{type}}がありません",
@@ -517,7 +508,6 @@
     },
     "allRunways": "すべて"
   },
-
   "layers": {
     "airport": {
       "title": "空港レイヤー",
@@ -561,7 +551,6 @@
     "showAll": "すべて表示",
     "hideAll": "すべて非表示"
   },
-
   "debug": {
     "title": "デバッグモード有効",
     "instruction": "マップ上の任意の要素をクリックしてプロパティを確認してください。",
@@ -578,7 +567,6 @@
     "copyToClipboard": "クリップボードにコピー",
     "clearSelection": "選択をクリア"
   },
-
   "launcher": {
     "title": "フライト設定",
     "launch": "X-Planeを起動",
@@ -588,7 +576,6 @@
     "xplaneRunning": "X-Planeが実行中 - フライトはAPIで変更されます",
     "selectDeparture": "マップ上で出発地を選択",
     "selectAircraft": "機体を選択",
-
     "aircraft": {
       "title": "機体",
       "search": "機体を検索...",
@@ -607,20 +594,17 @@
       "showAll": "すべて表示",
       "showFavoritesOnly": "お気に入りのみ表示"
     },
-
     "liveries": {
       "title": "塗装",
       "count": "塗装（{{count}}）",
       "default": "デフォルト"
     },
-
     "specs": {
       "emptyWeight": "空虚重量",
       "maxWeight": "MTOW",
       "maxFuel": "燃料容量",
       "tailNumber": "機体番号"
     },
-
     "config": {
       "timeOfDay": "時刻",
       "realWorldTime": "実時間",
@@ -632,12 +616,10 @@
       "departure": "出発",
       "livery": "塗装"
     },
-
     "startState": {
       "ready": "準備完了",
       "cold": "コールド＆ダーク"
     },
-
     "time": {
       "live": "ライブ",
       "set": "設定",
@@ -646,7 +628,6 @@
       "dusk": "夕暮れ",
       "night": "夜"
     },
-
     "timePresets": {
       "dawn": "夜明け",
       "sunrise": "日の出",
@@ -655,7 +636,6 @@
       "dusk": "夕暮れ",
       "night": "夜"
     },
-
     "weather": {
       "real": "実際",
       "clear": "快晴",
@@ -665,7 +645,6 @@
       "snowy": "雪",
       "foggy": "霧"
     },
-
     "weatherBuilder": {
       "custom": "カスタム天候",
       "customize": "天候をカスタマイズ",
@@ -694,29 +673,24 @@
         "cumulonimbus": "積乱雲"
       }
     },
-
     "weatherModal": {
       "presets": "プリセット",
       "custom": "カスタム",
       "poor": "悪い",
       "unlimited": "無制限"
     },
-
     "weatherDialog": {
       "title": "天候設定",
       "done": "完了",
       "addCloud": "雲レイヤー",
       "addWind": "風レイヤー",
-
       "layerProperties": "レイヤーのプロパティ",
       "emptyHint": "ダイアグラム内の雲または風レイヤーをクリックして編集",
-
       "cloudType": "雲の種類",
       "cloudCoverage": "雲量",
       "tops": "雲頂",
       "bases": "雲底",
       "deleteCloud": "雲レイヤー {{n}} を削除",
-
       "cloudTypes": {
         "cirrus": "巻雲",
         "stratus": "層雲",
@@ -729,7 +703,6 @@
         "broken": "Bkn",
         "overcast": "Ovc"
       },
-
       "altitude": "高度",
       "direction": "方向",
       "speed": "速度",
@@ -737,7 +710,6 @@
       "shear": "ウインドシアー",
       "turbulence": "乱気流",
       "deleteWind": "風レイヤー {{n}} を削除",
-
       "atmosphere": "大気",
       "visibility": "視程",
       "precipitation": "降水",
@@ -745,7 +717,6 @@
       "precipSevere": "激しい",
       "temperature": "気温",
       "altimeter": "高度計",
-
       "environment": "環境",
       "terrain": "地形",
       "terrainCondition": "状態",
@@ -763,7 +734,6 @@
         "medium": "中程度",
         "heavy": "強い"
       },
-
       "waves": "波",
       "waveHeight": "波高",
       "waveDirection": "方向",
@@ -781,19 +751,16 @@
         "rapidly_deteriorating": "急速に悪化"
       }
     },
-
     "fuelConfig": {
       "auto": "自動",
       "manual": "手動",
       "total": "合計"
     },
-
     "fuelModal": {
       "empty": "空",
       "full": "満タン",
       "of": "の"
     },
-
     "logbook": {
       "title": "フライトログ",
       "clearAll": "すべてクリア",
@@ -801,7 +768,6 @@
       "emptyHint": "起動後、最新10件のフライトがここに表示されます"
     }
   },
-
   "addonManager": {
     "title": "アドオンマネージャー",
     "openXPlaneFolder": "X-Planeフォルダを開く",
@@ -965,7 +931,6 @@
       "Navdata": "航法データ"
     }
   },
-
   "simbrief": {
     "title": "SimBriefからインポート",
     "description": "SimBriefから最新のフライトプランを取得",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -26,7 +26,6 @@
     "approved": "Zatwierdzone",
     "recommended": "Zalecane"
   },
-
   "units": {
     "ft": "ft",
     "m": "m",
@@ -36,7 +35,6 @@
     "kg": "kg",
     "fpm": "fpm"
   },
-
   "directions": {
     "n": "N",
     "e": "E",
@@ -47,11 +45,9 @@
     "se": "SE",
     "sw": "SW"
   },
-
   "app": {
     "title": "X-Dispatch"
   },
-
   "setup": {
     "title": "X-Dispatch",
     "subtitle": "Wybierz instalację X-Plane, aby rozpocząć",
@@ -62,7 +58,6 @@
     "failedToBrowse": "Nie udało się otworzyć wyboru folderu",
     "failedToSave": "Nie udało się zapisać"
   },
-
   "loading": {
     "title": "X-Dispatch",
     "badge": "Ładowanie danych",
@@ -85,7 +80,6 @@
     "scanningCustom": "Skanowanie Custom Scenery {{current}}/{{total}}: {{name}}",
     "savingToDb": "Zapisywanie do bazy danych..."
   },
-
   "toolbar": {
     "searchPlaceholder": "Szukaj lotnisk...",
     "clearSearch": "Wyczyść wyszukiwanie",
@@ -127,7 +121,6 @@
       "settings": "Otwórz ustawienia"
     }
   },
-
   "airportFilters": {
     "title": "Lotniska",
     "type": "Typ",
@@ -146,7 +139,6 @@
     "minRunways": "{{count}}+ Pasów",
     "reset": "Resetuj filtry"
   },
-
   "explore": {
     "title": "Eksploruj",
     "close": "Zamknij eksplorację",
@@ -189,7 +181,6 @@
       }
     }
   },
-
   "settings": {
     "title": "Ustawienia",
     "subtitle": "Skonfiguruj swoje preferencje",
@@ -335,7 +326,6 @@
       }
     }
   },
-
   "sidebar": {
     "weather": "Pogoda",
     "weatherDetails": "Szczegóły pogody",
@@ -370,7 +360,6 @@
       "noActivity": "Brak aktywności VATSIM"
     }
   },
-
   "airportInfo": {
     "tabs": {
       "info": "Info",
@@ -463,15 +452,19 @@
       "updateAvailable": "Gateway ma nowszą wersję",
       "credit": "od {{artist}} · {{date}}",
       "viewOnGateway": "Zobacz na Gateway"
+    },
+    "taxiRoute": {
+      "label": "Trasa kołowania",
+      "placeholder": "np. A B1 C",
+      "matchCount": "{{count}} odc.",
+      "noMatch": "brak dopasowania"
     }
   },
-
   "navigation": {
     "heading": "KURS",
     "wind": "WIATR",
     "calm": "Cisza"
   },
-
   "flightStrip": {
     "notDetected": "X-Plane nie uruchomiony",
     "ias": "IAS",
@@ -486,7 +479,6 @@
     "center": "Wyśrodkuj",
     "centerTooltip": "Wyśrodkuj mapę na samolocie"
   },
-
   "weather": {
     "fetching": "Pobieranie pogody...",
     "noData": "Brak danych pogodowych",
@@ -506,7 +498,6 @@
     "tailwind": "TW",
     "crosswind": "XW"
   },
-
   "procedures": {
     "noData": "Brak dostępnych procedur",
     "noTypeData": "Brak dostępnych {{type}}",
@@ -517,7 +508,6 @@
     },
     "allRunways": "WSZYSTKIE"
   },
-
   "layers": {
     "airport": {
       "title": "Warstwy lotniska",
@@ -561,7 +551,6 @@
     "showAll": "Pokaż wszystko",
     "hideAll": "Ukryj wszystko"
   },
-
   "debug": {
     "title": "Tryb debugowania aktywny",
     "instruction": "Kliknij dowolny element na mapie, aby sprawdzić jego właściwości.",
@@ -578,7 +567,6 @@
     "copyToClipboard": "Kopiuj do schowka",
     "clearSelection": "Wyczyść wybór"
   },
-
   "launcher": {
     "title": "Konfiguracja lotu",
     "launch": "Uruchom X-Plane",
@@ -588,7 +576,6 @@
     "xplaneRunning": "X-Plane działa - lot zostanie zmieniony przez API",
     "selectDeparture": "Wybierz miejsce odlotu na mapie",
     "selectAircraft": "Wybierz samolot",
-
     "aircraft": {
       "title": "Samolot",
       "search": "Szukaj samolotów...",
@@ -607,20 +594,17 @@
       "showAll": "Pokaż wszystkie",
       "showFavoritesOnly": "Pokaż tylko ulubione"
     },
-
     "liveries": {
       "title": "Malowania",
       "count": "Malowania ({{count}})",
       "default": "Domyślne"
     },
-
     "specs": {
       "emptyWeight": "Pusty",
       "maxWeight": "MTOW",
       "maxFuel": "Poj. paliwa",
       "tailNumber": "Nr ogonowy"
     },
-
     "config": {
       "timeOfDay": "Pora dnia",
       "realWorldTime": "Czas rzeczywisty",
@@ -632,12 +616,10 @@
       "departure": "Odlot",
       "livery": "Malowanie"
     },
-
     "startState": {
       "ready": "Gotowy",
       "cold": "Zimny i Wyłączony"
     },
-
     "time": {
       "live": "Na żywo",
       "set": "Ustaw",
@@ -646,7 +628,6 @@
       "dusk": "Zmierzch",
       "night": "Noc"
     },
-
     "timePresets": {
       "dawn": "Świt",
       "sunrise": "Wschód słońca",
@@ -655,7 +636,6 @@
       "dusk": "Zmierzch",
       "night": "Noc"
     },
-
     "weather": {
       "real": "Rzeczywista",
       "clear": "Czyste",
@@ -665,7 +645,6 @@
       "snowy": "Śnieżnie",
       "foggy": "Mgliście"
     },
-
     "weatherBuilder": {
       "custom": "Niestandardowa pogoda",
       "customize": "Dostosuj pogodę",
@@ -694,29 +673,24 @@
         "cumulonimbus": "Burzowe"
       }
     },
-
     "weatherModal": {
       "presets": "Presety",
       "custom": "Niestandardowa",
       "poor": "Słaba",
       "unlimited": "Nieograniczona"
     },
-
     "weatherDialog": {
       "title": "Ustawienia pogody",
       "done": "Gotowe",
       "addCloud": "Warstwa chmur",
       "addWind": "Warstwa wiatru",
-
       "layerProperties": "Właściwości warstwy",
       "emptyHint": "Kliknij warstwę chmur lub wiatru na diagramie, aby edytować",
-
       "cloudType": "Typ chmury",
       "cloudCoverage": "Pokrycie chmurami",
       "tops": "Szczyty",
       "bases": "Podstawy",
       "deleteCloud": "Usuń warstwę chmur {{n}}",
-
       "cloudTypes": {
         "cirrus": "Pierzaste",
         "stratus": "Warstwowe",
@@ -729,7 +703,6 @@
         "broken": "Bkn",
         "overcast": "Ovc"
       },
-
       "altitude": "Wysokość",
       "direction": "Kierunek",
       "speed": "Prędkość",
@@ -737,7 +710,6 @@
       "shear": "Uskoki wiatru",
       "turbulence": "Turbulencje",
       "deleteWind": "Usuń warstwę wiatru {{n}}",
-
       "atmosphere": "Atmosfera",
       "visibility": "Widoczność",
       "precipitation": "Opady",
@@ -745,7 +717,6 @@
       "precipSevere": "Silne",
       "temperature": "Temperatura",
       "altimeter": "Wysokościomierz",
-
       "environment": "Środowisko",
       "terrain": "Teren",
       "terrainCondition": "Stan",
@@ -763,7 +734,6 @@
         "medium": "Średnia",
         "heavy": "Silna"
       },
-
       "waves": "Fale",
       "waveHeight": "Wysokość",
       "waveDirection": "Kierunek",
@@ -781,19 +751,16 @@
         "rapidly_deteriorating": "Szybkie pogorszenie"
       }
     },
-
     "fuelConfig": {
       "auto": "Auto",
       "manual": "Ręczny",
       "total": "Suma"
     },
-
     "fuelModal": {
       "empty": "Pusty",
       "full": "Pełny",
       "of": "z"
     },
-
     "logbook": {
       "title": "Dziennik lotów",
       "clearAll": "Wyczyść wszystko",
@@ -801,7 +768,6 @@
       "emptyHint": "Twoje ostatnie 10 lotów pojawi się tutaj po uruchomieniu"
     }
   },
-
   "addonManager": {
     "title": "Menedżer dodatków",
     "openXPlaneFolder": "Otwórz folder X-Plane",
@@ -965,7 +931,6 @@
       "Navdata": "Dane nawigacyjne"
     }
   },
-
   "simbrief": {
     "title": "Importuj z SimBrief",
     "description": "Pobierz najnowszy plan lotu z SimBrief",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -26,7 +26,6 @@
     "approved": "Aprovado",
     "recommended": "Recomendado"
   },
-
   "units": {
     "ft": "ft",
     "m": "m",
@@ -36,7 +35,6 @@
     "kg": "kg",
     "fpm": "fpm"
   },
-
   "directions": {
     "n": "N",
     "e": "L",
@@ -47,11 +45,9 @@
     "se": "SE",
     "sw": "SO"
   },
-
   "app": {
     "title": "X-Dispatch"
   },
-
   "setup": {
     "title": "X-Dispatch",
     "subtitle": "Selecione sua instalação do X-Plane para começar",
@@ -62,7 +58,6 @@
     "failedToBrowse": "Falha ao abrir seletor de pastas",
     "failedToSave": "Falha ao salvar"
   },
-
   "loading": {
     "title": "X-Dispatch",
     "badge": "Carregando dados",
@@ -85,7 +80,6 @@
     "scanningCustom": "Analisando Custom Scenery {{current}}/{{total}}: {{name}}",
     "savingToDb": "Salvando no banco de dados..."
   },
-
   "toolbar": {
     "searchPlaceholder": "Pesquisar aeroportos...",
     "clearSearch": "Limpar pesquisa",
@@ -127,7 +121,6 @@
       "settings": "Abrir configurações"
     }
   },
-
   "airportFilters": {
     "title": "Aeroportos",
     "type": "Tipo",
@@ -146,7 +139,6 @@
     "minRunways": "{{count}}+ Pistas",
     "reset": "Redefinir filtros"
   },
-
   "explore": {
     "title": "Explorar",
     "close": "Fechar exploração",
@@ -189,7 +181,6 @@
       }
     }
   },
-
   "settings": {
     "title": "Configurações",
     "subtitle": "Configure suas preferências",
@@ -335,7 +326,6 @@
       }
     }
   },
-
   "sidebar": {
     "weather": "Clima",
     "weatherDetails": "Detalhes do clima",
@@ -370,7 +360,6 @@
       "noActivity": "Sem atividade VATSIM"
     }
   },
-
   "airportInfo": {
     "tabs": {
       "info": "Info",
@@ -463,15 +452,19 @@
       "updateAvailable": "Gateway tem uma versão mais recente",
       "credit": "por {{artist}} · {{date}}",
       "viewOnGateway": "Ver no Gateway"
+    },
+    "taxiRoute": {
+      "label": "Rota de táxi",
+      "placeholder": "ex. A B1 C",
+      "matchCount": "{{count}} seg",
+      "noMatch": "sem resultado"
     }
   },
-
   "navigation": {
     "heading": "PROA",
     "wind": "VENTO",
     "calm": "Calmo"
   },
-
   "flightStrip": {
     "notDetected": "X-Plane não está rodando",
     "ias": "IAS",
@@ -486,7 +479,6 @@
     "center": "Centralizar",
     "centerTooltip": "Centralizar mapa na aeronave"
   },
-
   "weather": {
     "fetching": "Obtendo clima...",
     "noData": "Sem dados meteorológicos disponíveis",
@@ -506,7 +498,6 @@
     "tailwind": "TW",
     "crosswind": "XW"
   },
-
   "procedures": {
     "noData": "Sem procedimentos disponíveis",
     "noTypeData": "Sem {{type}}s disponíveis",
@@ -517,7 +508,6 @@
     },
     "allRunways": "TODOS"
   },
-
   "layers": {
     "airport": {
       "title": "Camadas do aeroporto",
@@ -561,7 +551,6 @@
     "showAll": "Mostrar tudo",
     "hideAll": "Ocultar tudo"
   },
-
   "debug": {
     "title": "Modo debug ativo",
     "instruction": "Clique em qualquer elemento no mapa para inspecionar suas propriedades.",
@@ -578,7 +567,6 @@
     "copyToClipboard": "Copiar para área de transferência",
     "clearSelection": "Limpar seleção"
   },
-
   "launcher": {
     "title": "Configuração do voo",
     "launch": "Iniciar X-Plane",
@@ -588,7 +576,6 @@
     "xplaneRunning": "X-Plane está rodando - o voo será alterado via API",
     "selectDeparture": "Selecione uma partida no mapa",
     "selectAircraft": "Selecione uma aeronave",
-
     "aircraft": {
       "title": "Aeronave",
       "search": "Pesquisar aeronave...",
@@ -607,20 +594,17 @@
       "showAll": "Mostrar todos",
       "showFavoritesOnly": "Mostrar apenas favoritos"
     },
-
     "liveries": {
       "title": "Pinturas",
       "count": "Pinturas ({{count}})",
       "default": "Padrão"
     },
-
     "specs": {
       "emptyWeight": "Vazio",
       "maxWeight": "MTOW",
       "maxFuel": "Cap. combustível",
       "tailNumber": "Matrícula"
     },
-
     "config": {
       "timeOfDay": "Hora do dia",
       "realWorldTime": "Mundo real",
@@ -632,12 +616,10 @@
       "departure": "Partida",
       "livery": "Pintura"
     },
-
     "startState": {
       "ready": "Pronto",
       "cold": "Frio e Desligado"
     },
-
     "time": {
       "live": "Ao vivo",
       "set": "Definir",
@@ -646,7 +628,6 @@
       "dusk": "Entardecer",
       "night": "Noite"
     },
-
     "timePresets": {
       "dawn": "Amanhecer",
       "sunrise": "Nascer do sol",
@@ -655,7 +636,6 @@
       "dusk": "Entardecer",
       "night": "Noite"
     },
-
     "weather": {
       "real": "Real",
       "clear": "Limpo",
@@ -665,7 +645,6 @@
       "snowy": "Nevando",
       "foggy": "Nevoeiro"
     },
-
     "weatherBuilder": {
       "custom": "Clima personalizado",
       "customize": "Personalizar clima",
@@ -694,29 +673,24 @@
         "cumulonimbus": "Cumulonimbus"
       }
     },
-
     "weatherModal": {
       "presets": "Predefinições",
       "custom": "Personalizado",
       "poor": "Ruim",
       "unlimited": "Ilimitada"
     },
-
     "weatherDialog": {
       "title": "Configurações de clima",
       "done": "Concluído",
       "addCloud": "Camada de nuvens",
       "addWind": "Camada de vento",
-
       "layerProperties": "Propriedades da camada",
       "emptyHint": "Clique em uma camada de nuvens ou vento no diagrama para editar",
-
       "cloudType": "Tipo de nuvem",
       "cloudCoverage": "Cobertura de nuvens",
       "tops": "Topos",
       "bases": "Bases",
       "deleteCloud": "Excluir camada de nuvens {{n}}",
-
       "cloudTypes": {
         "cirrus": "Cirros",
         "stratus": "Stratus",
@@ -729,7 +703,6 @@
         "broken": "Bkn",
         "overcast": "Ovc"
       },
-
       "altitude": "Altitude",
       "direction": "Direção",
       "speed": "Velocidade",
@@ -737,7 +710,6 @@
       "shear": "Cisalhamento",
       "turbulence": "Turbulência",
       "deleteWind": "Excluir camada de vento {{n}}",
-
       "atmosphere": "Atmosfera",
       "visibility": "Visibilidade",
       "precipitation": "Precipitação",
@@ -745,7 +717,6 @@
       "precipSevere": "Severa",
       "temperature": "Temperatura",
       "altimeter": "Altímetro",
-
       "environment": "Ambiente",
       "terrain": "Terreno",
       "terrainCondition": "Condição",
@@ -763,7 +734,6 @@
         "medium": "Médio",
         "heavy": "Forte"
       },
-
       "waves": "Ondas",
       "waveHeight": "Altura",
       "waveDirection": "Direção",
@@ -781,19 +751,16 @@
         "rapidly_deteriorating": "Piora rápida"
       }
     },
-
     "fuelConfig": {
       "auto": "Auto",
       "manual": "Manual",
       "total": "Total"
     },
-
     "fuelModal": {
       "empty": "Vazio",
       "full": "Cheio",
       "of": "de"
     },
-
     "logbook": {
       "title": "Diário de voo",
       "clearAll": "Limpar tudo",
@@ -801,7 +768,6 @@
       "emptyHint": "Seus últimos 10 voos aparecerão aqui após o lançamento"
     }
   },
-
   "addonManager": {
     "title": "Gerenciador de Addons",
     "openXPlaneFolder": "Abrir pasta X-Plane",
@@ -965,7 +931,6 @@
       "Navdata": "Dados de navegação"
     }
   },
-
   "simbrief": {
     "title": "Importar do SimBrief",
     "description": "Buscar seu plano de voo mais recente do SimBrief",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -26,7 +26,6 @@
     "approved": "Одобрено",
     "recommended": "Рекомендуется"
   },
-
   "units": {
     "ft": "фут",
     "m": "м",
@@ -36,7 +35,6 @@
     "kg": "кг",
     "fpm": "фут/мин"
   },
-
   "directions": {
     "n": "С",
     "e": "В",
@@ -47,11 +45,9 @@
     "se": "ЮВ",
     "sw": "ЮЗ"
   },
-
   "app": {
     "title": "X-Dispatch"
   },
-
   "setup": {
     "title": "X-Dispatch",
     "subtitle": "Выберите установку X-Plane для начала работы",
@@ -62,7 +58,6 @@
     "failedToBrowse": "Не удалось открыть выбор папки",
     "failedToSave": "Не удалось сохранить"
   },
-
   "loading": {
     "title": "X-Dispatch",
     "badge": "Загрузка данных",
@@ -85,7 +80,6 @@
     "scanningCustom": "Сканирование Custom Scenery {{current}}/{{total}}: {{name}}",
     "savingToDb": "Сохранение в базу данных..."
   },
-
   "toolbar": {
     "searchPlaceholder": "Поиск аэропортов...",
     "clearSearch": "Очистить поиск",
@@ -127,7 +121,6 @@
       "settings": "Открыть настройки"
     }
   },
-
   "airportFilters": {
     "title": "Аэропорты",
     "type": "Тип",
@@ -146,7 +139,6 @@
     "minRunways": "{{count}}+ Полос",
     "reset": "Сбросить фильтры"
   },
-
   "explore": {
     "title": "Исследовать",
     "close": "Закрыть исследование",
@@ -189,7 +181,6 @@
       }
     }
   },
-
   "settings": {
     "title": "Настройки",
     "subtitle": "Настройте ваши предпочтения",
@@ -335,7 +326,6 @@
       }
     }
   },
-
   "sidebar": {
     "weather": "Погода",
     "weatherDetails": "Детали погоды",
@@ -370,7 +360,6 @@
       "noActivity": "Нет активности VATSIM"
     }
   },
-
   "airportInfo": {
     "tabs": {
       "info": "Инфо",
@@ -463,15 +452,19 @@
       "updateAvailable": "На Gateway есть более новый релиз",
       "credit": "от {{artist}} · {{date}}",
       "viewOnGateway": "Смотреть на Gateway"
+    },
+    "taxiRoute": {
+      "label": "Маршрут руления",
+      "placeholder": "напр. A B1 C",
+      "matchCount": "{{count}} сег",
+      "noMatch": "нет совпадений"
     }
   },
-
   "navigation": {
     "heading": "КУРС",
     "wind": "ВЕТЕР",
     "calm": "Штиль"
   },
-
   "flightStrip": {
     "notDetected": "X-Plane не запущен",
     "ias": "IAS",
@@ -486,7 +479,6 @@
     "center": "Центр",
     "centerTooltip": "Центрировать карту на самолёте"
   },
-
   "weather": {
     "fetching": "Получение погоды...",
     "noData": "Нет данных о погоде",
@@ -506,7 +498,6 @@
     "tailwind": "ПС",
     "crosswind": "БС"
   },
-
   "procedures": {
     "noData": "Нет доступных процедур",
     "noTypeData": "Нет доступных {{type}}",
@@ -517,7 +508,6 @@
     },
     "allRunways": "ВСЕ"
   },
-
   "layers": {
     "airport": {
       "title": "Слои аэропорта",
@@ -561,7 +551,6 @@
     "showAll": "Показать все",
     "hideAll": "Скрыть все"
   },
-
   "debug": {
     "title": "Режим отладки активен",
     "instruction": "Нажмите на любой элемент на карте, чтобы просмотреть его свойства.",
@@ -578,7 +567,6 @@
     "copyToClipboard": "Копировать в буфер",
     "clearSelection": "Очистить выбор"
   },
-
   "launcher": {
     "title": "Настройка полёта",
     "launch": "Запустить X-Plane",
@@ -588,7 +576,6 @@
     "xplaneRunning": "X-Plane запущен - полёт будет изменён через API",
     "selectDeparture": "Выберите точку вылета на карте",
     "selectAircraft": "Выберите самолёт",
-
     "aircraft": {
       "title": "Самолёт",
       "search": "Поиск самолётов...",
@@ -607,20 +594,17 @@
       "showAll": "Показать все",
       "showFavoritesOnly": "Только избранные"
     },
-
     "liveries": {
       "title": "Ливреи",
       "count": "Ливреи ({{count}})",
       "default": "По умолчанию"
     },
-
     "specs": {
       "emptyWeight": "Пустой",
       "maxWeight": "MTOW",
       "maxFuel": "Ёмкость топлива",
       "tailNumber": "Борт. номер"
     },
-
     "config": {
       "timeOfDay": "Время суток",
       "realWorldTime": "Реальное время",
@@ -632,12 +616,10 @@
       "departure": "Вылет",
       "livery": "Ливрея"
     },
-
     "startState": {
       "ready": "Готов",
       "cold": "Холодный и Тёмный"
     },
-
     "time": {
       "live": "В реальном времени",
       "set": "Установить",
@@ -646,7 +628,6 @@
       "dusk": "Сумерки",
       "night": "Ночь"
     },
-
     "timePresets": {
       "dawn": "Рассвет",
       "sunrise": "Восход",
@@ -655,7 +636,6 @@
       "dusk": "Сумерки",
       "night": "Ночь"
     },
-
     "weather": {
       "real": "Реальная",
       "clear": "Ясно",
@@ -665,7 +645,6 @@
       "snowy": "Снег",
       "foggy": "Туман"
     },
-
     "weatherBuilder": {
       "custom": "Пользовательская погода",
       "customize": "Настроить погоду",
@@ -694,29 +673,24 @@
         "cumulonimbus": "Кучево-дождевые"
       }
     },
-
     "weatherModal": {
       "presets": "Пресеты",
       "custom": "Пользовательская",
       "poor": "Плохая",
       "unlimited": "Неограниченная"
     },
-
     "weatherDialog": {
       "title": "Настройки погоды",
       "done": "Готово",
       "addCloud": "Слой облаков",
       "addWind": "Слой ветра",
-
       "layerProperties": "Свойства слоя",
       "emptyHint": "Нажмите на слой облаков или ветра на диаграмме для редактирования",
-
       "cloudType": "Тип облаков",
       "cloudCoverage": "Облачность",
       "tops": "Верхняя граница",
       "bases": "Нижняя граница",
       "deleteCloud": "Удалить слой облаков {{n}}",
-
       "cloudTypes": {
         "cirrus": "Перистые",
         "stratus": "Слоистые",
@@ -729,7 +703,6 @@
         "broken": "Bkn",
         "overcast": "Ovc"
       },
-
       "altitude": "Высота",
       "direction": "Направление",
       "speed": "Скорость",
@@ -737,7 +710,6 @@
       "shear": "Сдвиг ветра",
       "turbulence": "Турбулентность",
       "deleteWind": "Удалить слой ветра {{n}}",
-
       "atmosphere": "Атмосфера",
       "visibility": "Видимость",
       "precipitation": "Осадки",
@@ -745,7 +717,6 @@
       "precipSevere": "Сильные",
       "temperature": "Температура",
       "altimeter": "Альтиметр",
-
       "environment": "Окружение",
       "terrain": "Рельеф",
       "terrainCondition": "Состояние",
@@ -763,7 +734,6 @@
         "medium": "Средняя",
         "heavy": "Сильная"
       },
-
       "waves": "Волны",
       "waveHeight": "Высота",
       "waveDirection": "Направление",
@@ -781,19 +751,16 @@
         "rapidly_deteriorating": "Быстрое ухудшение"
       }
     },
-
     "fuelConfig": {
       "auto": "Авто",
       "manual": "Ручной",
       "total": "Всего"
     },
-
     "fuelModal": {
       "empty": "Пусто",
       "full": "Полный",
       "of": "из"
     },
-
     "logbook": {
       "title": "Журнал полётов",
       "clearAll": "Очистить всё",
@@ -801,7 +768,6 @@
       "emptyHint": "Ваши последние 10 полётов появятся здесь после запуска"
     }
   },
-
   "addonManager": {
     "title": "Менеджер дополнений",
     "openXPlaneFolder": "Открыть папку X-Plane",
@@ -965,7 +931,6 @@
       "Navdata": "Навигационные данные"
     }
   },
-
   "simbrief": {
     "title": "Импорт из SimBrief",
     "description": "Получить последний план полёта из SimBrief",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -26,7 +26,6 @@
     "approved": "已批准",
     "recommended": "推荐"
   },
-
   "units": {
     "ft": "英尺",
     "m": "米",
@@ -36,7 +35,6 @@
     "kg": "公斤",
     "fpm": "英尺/分"
   },
-
   "directions": {
     "n": "北",
     "e": "东",
@@ -47,11 +45,9 @@
     "se": "东南",
     "sw": "西南"
   },
-
   "app": {
     "title": "X-Dispatch"
   },
-
   "setup": {
     "title": "X-Dispatch",
     "subtitle": "选择您的 X-Plane 安装位置以开始使用",
@@ -62,7 +58,6 @@
     "failedToBrowse": "无法打开文件夹选择器",
     "failedToSave": "保存失败"
   },
-
   "loading": {
     "title": "X-Dispatch",
     "badge": "加载数据中",
@@ -85,7 +80,6 @@
     "scanningCustom": "正在扫描自定义地景 {{current}}/{{total}}: {{name}}",
     "savingToDb": "正在保存到数据库..."
   },
-
   "toolbar": {
     "searchPlaceholder": "搜索机场...",
     "clearSearch": "清除搜索",
@@ -127,7 +121,6 @@
       "settings": "打开设置"
     }
   },
-
   "airportFilters": {
     "title": "机场",
     "type": "类型",
@@ -146,7 +139,6 @@
     "minRunways": "{{count}}条以上",
     "reset": "重置筛选"
   },
-
   "explore": {
     "title": "探索",
     "close": "关闭探索",
@@ -189,7 +181,6 @@
       }
     }
   },
-
   "settings": {
     "title": "设置",
     "subtitle": "配置您的偏好设置",
@@ -335,7 +326,6 @@
       }
     }
   },
-
   "sidebar": {
     "weather": "天气",
     "weatherDetails": "天气详情",
@@ -370,7 +360,6 @@
       "noActivity": "无 VATSIM 活动"
     }
   },
-
   "airportInfo": {
     "tabs": {
       "info": "信息",
@@ -463,15 +452,19 @@
       "updateAvailable": "Gateway 有更新的版本",
       "credit": "{{artist}} · {{date}}",
       "viewOnGateway": "在 Gateway 上查看"
+    },
+    "taxiRoute": {
+      "label": "滑行路线",
+      "placeholder": "如 A B1 C",
+      "matchCount": "{{count}}段",
+      "noMatch": "无匹配"
     }
   },
-
   "navigation": {
     "heading": "航向",
     "wind": "风",
     "calm": "无风"
   },
-
   "flightStrip": {
     "notDetected": "X-Plane 未运行",
     "ias": "指示空速",
@@ -486,7 +479,6 @@
     "center": "居中",
     "centerTooltip": "将地图居中到飞机位置"
   },
-
   "weather": {
     "fetching": "正在获取天气...",
     "noData": "无天气数据",
@@ -506,7 +498,6 @@
     "tailwind": "顺风",
     "crosswind": "侧风"
   },
-
   "procedures": {
     "noData": "无可用程序",
     "noTypeData": "无可用 {{type}}",
@@ -517,7 +508,6 @@
     },
     "allRunways": "全部"
   },
-
   "layers": {
     "airport": {
       "title": "机场图层",
@@ -561,7 +551,6 @@
     "showAll": "全部显示",
     "hideAll": "全部隐藏"
   },
-
   "debug": {
     "title": "调试模式已启用",
     "instruction": "点击地图上的任意要素以查看其属性。",
@@ -578,7 +567,6 @@
     "copyToClipboard": "复制到剪贴板",
     "clearSelection": "清除选择"
   },
-
   "launcher": {
     "title": "飞行设置",
     "launch": "启动 X-Plane",
@@ -588,7 +576,6 @@
     "xplaneRunning": "X-Plane 正在运行 - 将通过 API 更改飞行",
     "selectDeparture": "在地图上选择出发地",
     "selectAircraft": "选择飞机",
-
     "aircraft": {
       "title": "飞机",
       "search": "搜索飞机...",
@@ -607,20 +594,17 @@
       "showAll": "显示全部",
       "showFavoritesOnly": "仅显示收藏"
     },
-
     "liveries": {
       "title": "涂装",
       "count": "涂装 ({{count}})",
       "default": "默认"
     },
-
     "specs": {
       "emptyWeight": "空重",
       "maxWeight": "最大起飞重量",
       "maxFuel": "燃油容量",
       "tailNumber": "机尾号"
     },
-
     "config": {
       "timeOfDay": "时间",
       "realWorldTime": "真实时间",
@@ -632,12 +616,10 @@
       "departure": "出发",
       "livery": "涂装"
     },
-
     "startState": {
       "ready": "就绪",
       "cold": "冷舱启动"
     },
-
     "time": {
       "live": "实时",
       "set": "设置",
@@ -646,7 +628,6 @@
       "dusk": "黄昏",
       "night": "夜晚"
     },
-
     "timePresets": {
       "dawn": "黎明",
       "sunrise": "日出",
@@ -655,7 +636,6 @@
       "dusk": "黄昏",
       "night": "夜晚"
     },
-
     "weather": {
       "real": "真实",
       "clear": "晴朗",
@@ -665,7 +645,6 @@
       "snowy": "雪天",
       "foggy": "雾天"
     },
-
     "weatherBuilder": {
       "custom": "自定义天气",
       "customize": "自定义天气",
@@ -694,29 +673,24 @@
         "cumulonimbus": "积雨云"
       }
     },
-
     "weatherModal": {
       "presets": "预设",
       "custom": "自定义",
       "poor": "较差",
       "unlimited": "无限制"
     },
-
     "weatherDialog": {
       "title": "天气设置",
       "done": "完成",
       "addCloud": "云层",
       "addWind": "风层",
-
       "layerProperties": "图层属性",
       "emptyHint": "点击图表中的云层或风层进行编辑",
-
       "cloudType": "云类型",
       "cloudCoverage": "云覆盖量",
       "tops": "云顶",
       "bases": "云底",
       "deleteCloud": "删除云层 {{n}}",
-
       "cloudTypes": {
         "cirrus": "卷云",
         "stratus": "层云",
@@ -729,7 +703,6 @@
         "broken": "Bkn",
         "overcast": "Ovc"
       },
-
       "altitude": "高度",
       "direction": "方向",
       "speed": "速度",
@@ -737,7 +710,6 @@
       "shear": "风切变",
       "turbulence": "湍流",
       "deleteWind": "删除风层 {{n}}",
-
       "atmosphere": "大气",
       "visibility": "能见度",
       "precipitation": "降水",
@@ -745,7 +717,6 @@
       "precipSevere": "强烈",
       "temperature": "温度",
       "altimeter": "高度表",
-
       "environment": "环境",
       "terrain": "地形",
       "terrainCondition": "状况",
@@ -763,7 +734,6 @@
         "medium": "中等",
         "heavy": "严重"
       },
-
       "waves": "海浪",
       "waveHeight": "浪高",
       "waveDirection": "方向",
@@ -781,19 +751,16 @@
         "rapidly_deteriorating": "快速恶化"
       }
     },
-
     "fuelConfig": {
       "auto": "自动",
       "manual": "手动",
       "total": "总计"
     },
-
     "fuelModal": {
       "empty": "空",
       "full": "满",
       "of": "的"
     },
-
     "logbook": {
       "title": "飞行日志",
       "clearAll": "清除全部",
@@ -801,7 +768,6 @@
       "emptyHint": "启动后，您最近的10次飞行将显示在此处"
     }
   },
-
   "addonManager": {
     "title": "插件管理器",
     "openXPlaneFolder": "打开 X-Plane 文件夹",
@@ -965,7 +931,6 @@
       "Navdata": "导航数据"
     }
   },
-
   "simbrief": {
     "title": "从SimBrief导入",
     "description": "从SimBrief获取最新的飞行计划",

--- a/src/stores/taxiRouteStore.ts
+++ b/src/stores/taxiRouteStore.ts
@@ -1,0 +1,73 @@
+/**
+ * Taxi Route Store
+ * Manages taxi route state for airport ground navigation.
+ *
+ * Users click on the map to add waypoints, creating a connected
+ * taxi route path. Simple, reliable, no pathfinding confusion.
+ * Text input is still available for reference but clicking is primary.
+ */
+import { create } from 'zustand';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface TaxiRoutePoint {
+  longitude: number;
+  latitude: number;
+}
+
+interface TaxiRouteState {
+  /** Ordered waypoints clicked by the user */
+  waypoints: TaxiRoutePoint[];
+  /** ICAO of the airport taxi mode is active for, or null when inactive */
+  activeTaxiIcao: string | null;
+  /** Whether click-to-add mode is enabled */
+  clickModeEnabled: boolean;
+
+  // Actions
+  setActiveAirport: (icao: string) => void;
+  addWaypoint: (lon: number, lat: number) => void;
+  removeLastWaypoint: () => void;
+  clearRoute: () => void;
+  deactivate: () => void;
+  setClickModeEnabled: (enabled: boolean) => void;
+}
+
+// ============================================================================
+// Store
+// ============================================================================
+
+export const useTaxiRouteStore = create<TaxiRouteState>()((set) => ({
+  waypoints: [],
+  activeTaxiIcao: null,
+  clickModeEnabled: false,
+
+  setActiveAirport: (icao: string) =>
+    set({ activeTaxiIcao: icao.toUpperCase(), waypoints: [], clickModeEnabled: false }),
+
+  addWaypoint: (lon, lat) =>
+    set((state) => ({
+      waypoints: [...state.waypoints, { longitude: lon, latitude: lat }],
+    })),
+
+  removeLastWaypoint: () =>
+    set((state) => ({
+      waypoints: state.waypoints.length > 0 ? state.waypoints.slice(0, -1) : state.waypoints,
+    })),
+
+  clearRoute: () => set({ waypoints: [] }),
+
+  deactivate: () => set({ activeTaxiIcao: null, waypoints: [], clickModeEnabled: false }),
+
+  setClickModeEnabled: (enabled: boolean) => set({ clickModeEnabled: enabled }),
+}));
+
+// ============================================================================
+// Derived selectors
+// ============================================================================
+
+/** Whether taxi route mode is active. */
+export function useTaxiModeActive(): boolean {
+  return useTaxiRouteStore((s) => s.activeTaxiIcao !== null);
+}


### PR DESCRIPTION
## Summary
Click-to-add taxi route feature using canvas overlay on the map.

## Changes
- Click on map to add numbered waypoints
- Green glow lines with animated pulse dashes
- Direction arrows along route segments
- TaxiRouteInline panel with undo/clear/toggle/close buttons
- clickModeEnabled disabled by default for better UX

## Testing
- Tested at EIDW (Dublin)
- Visual confirmation of canvas rendering, animations, and waypoint markers

## Files Changed
- src/components/Map/hooks/useTaxiRouteSync.ts (new)
- src/components/layout/AirportInfoPanel/tabs/TaxiRouteInline.tsx (new)
- src/stores/taxiRouteStore.ts (new)